### PR TITLE
Make status-parsing more robust

### DIFF
--- a/JMPDComm/src/org/a0z/mpd/MPDStatus.java
+++ b/JMPDComm/src/org/a0z/mpd/MPDStatus.java
@@ -103,6 +103,15 @@ public class MPDStatus {
 	 * @param response
 	 */
 	public void updateStatus(List<String> response) {
+		try {
+			doStatusUpdate(response);
+		} catch(RuntimeException e) {
+			//Do nothing, these should be harmless
+		}
+	}
+
+	private void doStatusUpdate(List<String> response)
+	{
 		for (String line : response) {
 			if (line.startsWith("volume:")) {
 				this.volume = Integer.parseInt(line.substring("volume: ".length()));


### PR DESCRIPTION
When mopidy enters this particular state (which is now a reported mopidy bug) mpdroid becomes unusable and simply disconnects at once. This makes it more robust in that case. This only handles status-updates, and nothing else.
