### PR TITLE
Bug in MPDAsyncHelper

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/MPDAsyncHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/MPDAsyncHelper.java
@@ -96,6 +96,7 @@ public class MPDAsyncHelper extends Handler {
 	 * the information back to the listeners of the matching events...
 	 */
 	public void handleMessage(Message msg) {
+		try {
 		Object[] args = (Object[]) msg.obj;
 		switch (msg.what) {
 		case EVENT_CONNECTIONSTATE:
@@ -154,6 +155,9 @@ public class MPDAsyncHelper extends Handler {
 			for (AsyncExecListener listener : asyncExecListeners)
 				listener.asyncExecSucceeded(msg.arg1);
 			break;
+		}
+		} catch(ClassCastException e) {
+			// happens when unknown message type is received
 		}
 	}
 


### PR DESCRIPTION
When I start dmix for the first time I see a ClassCastException on the console caused by a different kind of message send to the helper. This change handles the exception by ignoring it because the message is not interesting anyway.
