### PR TITLE
Support songs without album tags

### DIFF
--- a/JMPDComm/src/org/a0z/mpd/Album.java
+++ b/JMPDComm/src/org/a0z/mpd/Album.java
@@ -1,6 +1,9 @@
 package org.a0z.mpd;
 
-public class Album extends Item {
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Album extends Item implements Parcelable {
 	public static String singleTrackFormat="%1 Track (%2)";
 	public static String multipleTracksFormat="%1 Tracks (%2)";
 
@@ -8,30 +11,30 @@ public class Album extends Item {
 	private final long songCount;
 	private final long duration;
 	private final long year;
-	private final String artist;
 
 	public Album(String name, long songCount, long duration, long year) {
 		this.name=name;
 		this.songCount=songCount;
 		this.duration=duration;
 		this.year=year;
-		this.artist=null;
 	}
 
-	public Album(String name, String artist) {
+	public Album(String name) {
 		this.name=name;
 		this.songCount=0;
 		this.duration=0;
 		this.year=0;
-		this.artist=artist;
 	}
+
+	protected Album(Parcel in) {
+		this.name=in.readString();
+		this.songCount=in.readLong();
+		this.duration=in.readLong();
+		this.year=in.readLong();
+    }
 
 	public String getName() {
 		return name;
-	}
-
-	public String getArtist() {
-		return artist;
 	}
 
 	public long getSongCount() {
@@ -75,4 +78,30 @@ public class Album extends Item {
     	}
     	return super.compareTo(o);
     }
+
+
+	@Override
+	public int describeContents() {
+		return 0;
+	}
+ 
+	@Override
+	public void writeToParcel(Parcel dest, int flags) {
+		dest.writeString(this.name);
+		dest.writeLong(this.songCount);
+		dest.writeLong(this.duration);
+		dest.writeLong(this.year);
+	}
+
+	public static final Parcelable.Creator CREATOR =
+    	new Parcelable.Creator() {
+            public Album createFromParcel(Parcel in) {
+                return new Album(in);
+            }
+ 
+            public Album[] newArray(int size) {
+                return new Album[size];
+            }
+        };
+
 }

--- a/JMPDComm/src/org/a0z/mpd/Artist.java
+++ b/JMPDComm/src/org/a0z/mpd/Artist.java
@@ -1,6 +1,9 @@
 package org.a0z.mpd;
 
-public class Artist extends Item {
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class Artist extends Item implements Parcelable {
 	public static String singleAlbumFormat="%1 Album";
 	public static String multipleAlbumsFormat="%1 Albums";
 
@@ -19,6 +22,12 @@ public class Artist extends Item {
 		}
 		this.albumCount=albumCount;
 	}
+
+	protected Artist(Parcel in) {
+		this.name=in.readString();
+		this.sort=in.readString();
+		this.albumCount=in.readInt();
+    }
 
 	public String getName() {
 		return name;
@@ -59,4 +68,28 @@ public class Artist extends Item {
     public boolean equals(Object o) {
     	return (o instanceof Artist) && ((Artist)o).name.equals(name);
     }
+
+
+	@Override
+	public int describeContents() {
+		return 0;
+	}
+ 
+	@Override
+	public void writeToParcel(Parcel dest, int flags) {
+		dest.writeString(this.name);
+		dest.writeString(this.sort);
+		dest.writeInt(this.albumCount);
+	}
+
+	public static final Parcelable.Creator CREATOR =
+    	new Parcelable.Creator() {
+            public Artist createFromParcel(Parcel in) {
+                return new Artist(in);
+            }
+ 
+            public Artist[] newArray(int size) {
+                return new Artist[size];
+            }
+        };
 }

--- a/JMPDComm/src/org/a0z/mpd/UnknownAlbum.java
+++ b/JMPDComm/src/org/a0z/mpd/UnknownAlbum.java
@@ -1,0 +1,32 @@
+package org.a0z.mpd;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class UnknownAlbum extends Album {
+
+	public UnknownAlbum() {
+		super("Unknown Album");
+	}
+
+	protected UnknownAlbum(Parcel in) {
+		super(in);
+	}
+
+	@Override
+	public String subText() {
+		return "";
+	}
+
+	public static final Parcelable.Creator CREATOR =
+    	new Parcelable.Creator() {
+            public UnknownAlbum createFromParcel(Parcel in) {
+                return new UnknownAlbum(in);
+            }
+ 
+            public UnknownAlbum[] newArray(int size) {
+                return new UnknownAlbum[size];
+            }
+        };
+
+}

--- a/MPDroid/src/com/namelessdev/mpdroid/SearchActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/SearchActivity.java
@@ -125,8 +125,7 @@ public class SearchActivity extends SherlockListActivity implements OnMenuItemCl
 		} else if(o instanceof Artist) {
 			return ((Artist) o).getName();
 		} else if(o instanceof Album) {
-			String artist=((Album) o).getArtist();
-			return null==artist ? ((Album) o).getName() : artist+" - "+((Album) o).getName();
+			return ((Album) o).getName();
 		}
 		return "";
 	}
@@ -151,12 +150,11 @@ public class SearchActivity extends SherlockListActivity implements OnMenuItemCl
 			add((Music) selectedItem);
 		} else if(selectedItem instanceof Artist) {
 			Intent intent = new Intent(this, AlbumsActivity.class);
-			intent.putExtra("artist", ((Artist) selectedItem).getName());
+			intent.putExtra("artist", ((Artist) selectedItem));
 			startActivityForResult(intent, -1);
 		} else if(selectedItem instanceof Album) {
 			Intent intent = new Intent(this, SongsActivity.class);
-			//intent.putExtra("artist", ((Album) selectedItem).getArtist());
-			intent.putExtra("album", ((Album) selectedItem).getName());
+			intent.putExtra("album", ((Album) selectedItem));
 			startActivityForResult(intent, -1);
 		}
 	}
@@ -166,20 +164,18 @@ public class SearchActivity extends SherlockListActivity implements OnMenuItemCl
 		if(object instanceof Music) {
 			add((Music) object);
 		} else if (object instanceof Artist) {
-			add(((Artist) object).getName(), null);
+			add(((Artist) object), null);
 		} else if (object instanceof Album) {
-			add(((Album) object).getArtist(), ((Album) object).getName());
+			add(null, ((Album) object));
 		}
 	}
 	
-	protected void add(String artist, String album) {
+	protected void add(Artist artist, Album album) {
 		try {
 			MPDApplication app = (MPDApplication) getApplication();
 			ArrayList<Music> songs = new ArrayList<Music>(app.oMPDAsyncHelper.oMPD.getSongs(artist, album));
 			app.oMPDAsyncHelper.oMPD.getPlaylist().addAll(songs);
-			Tools.notifyUser(
-					String.format(getResources().getString(addedString), null == album ? artist : (null == artist ? album : artist + " - "
-							+ album)), this);
+			Tools.notifyUser(String.format(getResources().getString(addedString), null == album ? artist.getName() : (null == artist ? album.getName() : artist.getName() + " - " + album.getName())), this);
 		} catch (MPDServerException e) {
 			e.printStackTrace();
 		}
@@ -318,7 +314,7 @@ public class SearchActivity extends SherlockListActivity implements OnMenuItemCl
 						valueFound = true;
 				}
 				if(!valueFound)
-					albumItems.add(new Album(tmpValue, music.getArtist()));
+					albumItems.add(new Album(tmpValue));
 			}			
 		}
 		

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
@@ -3,6 +3,9 @@ package com.namelessdev.mpdroid.fragments;
 import org.a0z.mpd.Item;
 import org.a0z.mpd.MPD;
 import org.a0z.mpd.exception.MPDServerException;
+import org.a0z.mpd.Artist;
+import org.a0z.mpd.Album;
+import org.a0z.mpd.UnknownAlbum;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -19,7 +22,7 @@ import com.namelessdev.mpdroid.views.AlbumDataBinder;
 
 public class AlbumsFragment extends BrowseFragment {
 	private MPDApplication app;
-	private String artist = "";
+	private Artist artist = null;
 
 	public AlbumsFragment() {
 		super(R.string.addAlbum, R.string.albumAdded, MPD.MPD_SEARCH_ALBUM);
@@ -40,20 +43,20 @@ public class AlbumsFragment extends BrowseFragment {
 		super.onActivityCreated(savedInstanceState);
 		app = (MPDApplication) getActivity().getApplication();
 		registerForContextMenu(getListView());
-		UpdateList();
-		if (getActivity().getIntent().getStringExtra("artist") != null) {
-			artist=getActivity().getIntent().getStringExtra("artist");
-			setActivityTitle(artist);
+		artist = getActivity().getIntent().getParcelableExtra("artist");
+		if (artist != null) {
+			setActivityTitle(artist.getName());
 		} else {
 			getActivity().setTitle(getResources().getString(R.string.albums));
 		}
+		UpdateList();
 	}
 
 	@Override
 	public void onListItemClick(ListView l, View v, int position, long id) {
 		Intent intent = new Intent(getActivity(), SongsActivity.class);
-		intent.putExtra("album", items.get(position).getName());
-		intent.putExtra("artist", getActivity().getIntent().getStringExtra("artist"));
+		intent.putExtra("album", ((Album) items.get(position)));
+		intent.putExtra("artist", artist);
 		startActivityForResult(intent, -1);
 	}
 	
@@ -68,7 +71,7 @@ public class AlbumsFragment extends BrowseFragment {
 	@Override
 	protected void asyncUpdate() {
 		try {
-			items = app.oMPDAsyncHelper.oMPD.getAlbums(getActivity().getIntent().getStringExtra("artist"));
+			items = app.oMPDAsyncHelper.oMPD.getAlbums(artist);
 		} catch (MPDServerException e) {
 		}
 	}
@@ -76,7 +79,7 @@ public class AlbumsFragment extends BrowseFragment {
     @Override
     protected void Add(Item item) {
     	try {
-    		app.oMPDAsyncHelper.oMPD.getPlaylist().addAll(app.oMPDAsyncHelper.oMPD.getSongs(artist, item.getName()));
+			app.oMPDAsyncHelper.oMPD.getPlaylist().addAll(app.oMPDAsyncHelper.oMPD.getSongs(artist, ((Album) item)));
     		Tools.notifyUser(String.format(getResources().getString(irAdded), item), getActivity());
     	} catch (MPDServerException e) {
     		e.printStackTrace();
@@ -86,7 +89,7 @@ public class AlbumsFragment extends BrowseFragment {
     @Override
     protected void Add(Item item, String playlist) {
     	try {
-    		app.oMPDAsyncHelper.oMPD.addToPlaylist(playlist, app.oMPDAsyncHelper.oMPD.getSongs(artist, item.getName()));
+			app.oMPDAsyncHelper.oMPD.addToPlaylist(playlist, app.oMPDAsyncHelper.oMPD.getSongs(artist, ((Album) item)));
     		Tools.notifyUser(String.format(getResources().getString(irAdded), item), getActivity());
     	} catch (MPDServerException e) {
     		e.printStackTrace();

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/ArtistsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/ArtistsFragment.java
@@ -3,6 +3,7 @@ package com.namelessdev.mpdroid.fragments;
 import org.a0z.mpd.Item;
 import org.a0z.mpd.MPD;
 import org.a0z.mpd.exception.MPDServerException;
+import org.a0z.mpd.Artist;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -47,7 +48,7 @@ public class ArtistsFragment extends BrowseFragment {
 	@Override
 	public void onListItemClick(ListView l, View v, int position, long id) {
 		Intent intent = new Intent(getActivity(), AlbumsActivity.class);
-		intent.putExtra("artist", items.get(position).getName());
+		intent.putExtra("artist", ((Artist) items.get(position)));
 		startActivityForResult(intent, -1);
 	}
 
@@ -64,7 +65,7 @@ public class ArtistsFragment extends BrowseFragment {
     protected void Add(Item item) {
     	try {
     		MPDApplication app = (MPDApplication) getActivity().getApplication();
-    		app.oMPDAsyncHelper.oMPD.getPlaylist().addAll(app.oMPDAsyncHelper.oMPD.getSongs(item.getName(), null));
+    		app.oMPDAsyncHelper.oMPD.getPlaylist().addAll(app.oMPDAsyncHelper.oMPD.getSongs(((Artist) item), null));
     		Tools.notifyUser(String.format(getResources().getString(irAdded), item), getActivity());
     	} catch (MPDServerException e) {
     		e.printStackTrace();
@@ -75,7 +76,7 @@ public class ArtistsFragment extends BrowseFragment {
     protected void Add(Item item, String playlist) {
     	try {
     		MPDApplication app = (MPDApplication) getActivity().getApplication();
-    		app.oMPDAsyncHelper.oMPD.addToPlaylist(playlist, app.oMPDAsyncHelper.oMPD.getSongs(item.getName(), null));
+    		app.oMPDAsyncHelper.oMPD.addToPlaylist(playlist, app.oMPDAsyncHelper.oMPD.getSongs(((Artist) item), null));
     		Tools.notifyUser(String.format(getResources().getString(irAdded), item), getActivity());
     	} catch (MPDServerException e) {
     		e.printStackTrace();

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/SongsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/SongsFragment.java
@@ -6,6 +6,8 @@ import org.a0z.mpd.Item;
 import org.a0z.mpd.MPD;
 import org.a0z.mpd.Music;
 import org.a0z.mpd.exception.MPDServerException;
+import org.a0z.mpd.Artist;
+import org.a0z.mpd.Album;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -23,8 +25,8 @@ import com.namelessdev.mpdroid.views.SongDataBinder;
 
 public class SongsFragment extends BrowseFragment {
 
-	String album = "";
-	String artist = "";
+	Album album = null;
+	Artist artist = null;
 	TextView headerArtist;
 	TextView headerInfo;
 
@@ -57,11 +59,11 @@ public class SongsFragment extends BrowseFragment {
 	public void onActivityCreated(Bundle savedInstanceState) {
 		super.onActivityCreated(savedInstanceState);
 		registerForContextMenu(getListView());
-		album = (String) this.getActivity().getIntent().getStringExtra("album");
-		artist = (String) this.getActivity().getIntent().getStringExtra("artist");
+		artist = getActivity().getIntent().getParcelableExtra("artist");
+		album = getActivity().getIntent().getParcelableExtra("album");
 		UpdateList();
 
-		setActivityTitle(album);
+		setActivityTitle(album.getName());
 
 	}
 


### PR DESCRIPTION
Side-effect is passing Album & Artist objects as parcelables, instead of strings.

I'm not sure about other MP3 collections, but mine have a lot of single tracks which don't belong on an album. This patch adds support for the them.
