### PR TITLE
Closing non existing connection bugfix

### DIFF
--- a/JMPDComm/src/org/a0z/mpd/MPD.java
+++ b/JMPDComm/src/org/a0z/mpd/MPD.java
@@ -145,7 +145,7 @@ public class MPD {
      */
     public List<String> waitForChanges() throws MPDServerException {
 
-        while (mpdIdleConnection != null) {
+        while (mpdIdleConnection != null && mpdIdleConnection.isConnected()) {
             List<String> data = mpdIdleConnection
                     .sendAsyncCommand(MPDCommand.MPD_CMD_IDLE);
             if (data.isEmpty()) {


### PR DESCRIPTION
Fix https://github.com/abarisain/dmix/issues/163

I also removed the check on mpdIdleconnection in MPD.IsConnected() that I added before, as it may lead to incorrect behavior.

Changed the condition in the idle loop with proper exception throwing.
