### PR TITLE
Don't save cover art again when read from cache

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverAsyncHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverAsyncHelper.java
@@ -177,24 +177,29 @@ public class CoverAsyncHelper extends Handler {
 					cover = getBitmapForRetriever((CoverInfo) msg.obj, coverRetriever);
 					if (cover != null) {
 						Log.i(MPDApplication.TAG, "Found cover art using retriever : " + coverRetriever.getName());
+						// if cover is not read from cache
+						if (!(coverRetriever instanceof CachedCover)) {
+							// Save this cover into cache, if it is enabled.
+							for (ICoverRetriever coverRetriever1 : coverRetrievers) {
+								if (coverRetriever1 instanceof CachedCover) {
+									Log.i(MPDApplication.TAG, "Saving cover art to cache");
+									((CachedCover) coverRetriever1).save(((CoverInfo) msg.obj).sArtist, ((CoverInfo) msg.obj).sAlbum, cover);
+								}
+							}	
+						}
+						CoverAsyncHelper.this.obtainMessage(EVENT_COVERDOWNLOADED, cover).sendToTarget();
 						break;
-					}
+					}	
 				}
 				if (cover == null) {
+					Log.i(MPDApplication.TAG, "No cover art found");
 					CoverAsyncHelper.this.obtainMessage(EVENT_COVERNOTFOUND).sendToTarget();
-				} else {
-					// Save this cover into cache, if it is enabled.
-					for (ICoverRetriever coverRetriever : coverRetrievers) {
-						if (coverRetriever instanceof CachedCover) {
-							((CachedCover) coverRetriever).save(((CoverInfo) msg.obj).sArtist, ((CoverInfo) msg.obj).sAlbum, cover);
-						}
-					}
-					CoverAsyncHelper.this.obtainMessage(EVENT_COVERDOWNLOADED, cover).sendToTarget();
 				}
 				break;
 			default:
 			}
-		}
+		}	
+
 	}
 
 	private Bitmap download(String url) {


### PR DESCRIPTION
Hi,

really like your implementation of cover art caching! Covers are shown immediately now!

There is just a little bug. 
The quality of a cover art image in the cache is getting worse every time it is shown. 
This is because after been loaded from cache the cover is compressed and saved to the cache again.

With this patch cover art is only saved when not read from cache.
