### PR TITLE
Fixed crash when trying to clear cache on devices with no sd-card

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/cover/CachedCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/CachedCover.java
@@ -59,7 +59,10 @@ public class CachedCover implements ICoverRetriever {
 	}
 
 	public void clear() {
-		final File cacheFolder = new File(getAbsoluteCoverFolderPath());
+		final String cacheFolderPath = getAbsoluteCoverFolderPath();
+		if (cacheFolderPath == null)
+			return;
+		final File cacheFolder = new File(cacheFolderPath);
 		if (!cacheFolder.exists()) {
 			return;
 		}


### PR DESCRIPTION
Little fix. MPDroid crashes on devices with no sd-card if you try to clear the non existing cache.
