### PR TITLE
Show alert dialog before clearing cache

### DIFF
--- a/MPDroid/res/values/strings.xml
+++ b/MPDroid/res/values/strings.xml
@@ -198,6 +198,6 @@
 	<string name="enableLocalCoverCacheDescription">Saves downloaded cover art on the device for faster retrieval</string>
 	<string name="clearLocalCoverCache">Clear cover art cache</string>
 	<string name="clearLocalCoverCacheDescription">Free the storage space used by the cover art cache</string>
-	
+    <string name="clearLocalCoverCachePrompt">Delete all cached cover art?</string>
 	
 </resources>

--- a/MPDroid/src/com/namelessdev/mpdroid/SettingsActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/SettingsActivity.java
@@ -9,6 +9,8 @@ import org.a0z.mpd.MPDStatus;
 import org.a0z.mpd.event.StatusChangeListener;
 import org.a0z.mpd.exception.MPDServerException;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -207,7 +209,21 @@ public class SettingsActivity extends PreferenceActivity implements
 			return true;
 
 		} else if (preference.getKey().equals("clearLocalCoverCache")) {
-			new CachedCover(app).clear();
+			new AlertDialog.Builder(this)
+		    .setTitle(R.string.clearLocalCoverCache)
+		    .setMessage(R.string.clearLocalCoverCachePrompt)
+			.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+		        public void onClick(DialogInterface dialog, int which) { 
+		    		MPDApplication app = (MPDApplication) getApplication();
+					new CachedCover(app).clear();
+		        }
+		     })
+		    .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+		        public void onClick(DialogInterface dialog, int which) { 
+		            // do nothing
+		        }
+		     })
+		     .show();		
 			return true;
 
 		} else if (preference.getKey().equals("enableLocalCover")) {


### PR DESCRIPTION
Users get no feedback when they press "Clear cover art cache".
This patch adds an alert dialog to confirm the clearing.
