### PR TITLE
Issue #184 - Add an option to disable cover art download on 3G

### DIFF
--- a/MPDroid/res/layout/settings.xml
+++ b/MPDroid/res/layout/settings.xml
@@ -86,6 +86,10 @@
 			<EditTextPreference android:persistent="true"
 				android:title="@string/coverFileName" android:summary="@string/coverFileNameDescription"
 				android:key="coverFileName" android:defaultValue="folder.jpg" />
+			<CheckBoxPreference android:persistent="true"
+				android:title="@string/enableCoverOnlyOnWifi"
+				android:summary="@string/enableCoverOnlyOnWifiDescription"
+				android:key="enableCoverOnlyOnWifi" android:defaultValue="false"/>
 		</PreferenceScreen>
 		<CheckBoxPreference android:persistent="true"
 			android:title="@string/enableStopButton"

--- a/MPDroid/res/values/strings.xml
+++ b/MPDroid/res/values/strings.xml
@@ -208,5 +208,7 @@
     <string name="actionSongSelected">1 song selected</string>
     <string name="actionSongsSelected">%s songs selected</string>
     <string name="searchQueue">Search play queue …</string>
-	
+    <string name="enableCoverOnlyOnWifi">Download only on WiFi</string>
+    <string name="enableCoverOnlyOnWifiDescription">For people with tight 3G usage limits. Cashed covers will be used anyway.</string>
+
 </resources>


### PR DESCRIPTION
I've added checkbox "Download cover art only on wifi" in cover settings.
It works exactly as it should. Covers wouldn't be loaded through 3G, only through wifi and from cache.
