### PR TITLE
Display and cache album art from any source in the artist's album listing

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverAsyncHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverAsyncHelper.java
@@ -125,7 +125,7 @@ public class CoverAsyncHelper extends Handler {
 	/**
 	 * Checks if device connected or connecting to wifi network
 	 */
-	private boolean isWifi() {
+	public boolean isWifi() {
 		ConnectivityManager conMan = (ConnectivityManager) app.getSystemService(Context.CONNECTIVITY_SERVICE);
 		// Get status of wifi connection
 		State wifi = conMan.getNetworkInfo(1).getState();

--- a/MPDroid/src/com/namelessdev/mpdroid/views/AlbumDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/AlbumDataBinder.java
@@ -2,14 +2,18 @@ package com.namelessdev.mpdroid.views;
 
 import java.util.List;
 
+import org.a0z.mpd.Artist;
 import org.a0z.mpd.Album;
 import org.a0z.mpd.Item;
 import org.a0z.mpd.Music;
+import org.a0z.mpd.exception.MPDServerException;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.TypedArray;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.BitmapDrawable;
 import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.view.View;
@@ -22,10 +26,12 @@ import com.namelessdev.mpdroid.adapters.ArrayIndexerDataBinder;
 import com.namelessdev.mpdroid.cover.CachedCover;
 import com.namelessdev.mpdroid.cover.CoverBitmapDrawable;
 import com.namelessdev.mpdroid.helpers.CoverAsyncHelper;
+import com.namelessdev.mpdroid.helpers.CoverAsyncHelper.CoverDownloadListener;
 import com.namelessdev.mpdroid.tools.Tools;
 
 public class AlbumDataBinder implements ArrayIndexerDataBinder {
-	CachedCover coverHelper = null;
+	CoverAsyncHelper coverHelper = null;
+	Context context = null;
 	String artist = null;
 	MPDApplication app = null;
 	boolean lightTheme = false;
@@ -34,13 +40,10 @@ public class AlbumDataBinder implements ArrayIndexerDataBinder {
 		this.app = app;
 		this.artist = artist;
 		this.lightTheme = isLightTheme;
-		final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(app);
-		if (artist != null && settings.getBoolean(CoverAsyncHelper.PREFERENCE_CACHE, true)) {
-			coverHelper = new CachedCover(app);
-		}
 	}
 
 	public void onDataBind(final Context context, final View targetView, List<? extends Item> items, Object item, int position) {
+		this.context = context;
 		final Album album = (Album) item;
 		String info = "";
 		final long songCount = album.getSongCount();
@@ -59,44 +62,99 @@ public class AlbumDataBinder implements ArrayIndexerDataBinder {
 		} else {
 			albumInfo.setVisibility(View.GONE);
 		}
-		if (coverHelper != null) {
-			final ImageView albumCover = (ImageView) targetView.findViewById(R.id.albumCover);
-			final Drawable oldDrawable = albumCover.getDrawable();
-			albumCover.setImageResource(lightTheme ? R.drawable.no_cover_art_light : R.drawable.no_cover_art);
-			if (oldDrawable != null && oldDrawable instanceof CoverBitmapDrawable) {
-				final Bitmap oldBitmap = ((CoverBitmapDrawable) oldDrawable).getBitmap();
-				if (oldBitmap != null)
-					oldBitmap.recycle();
-			}
-			final Handler handler = new Handler();
-			new Thread(new Runnable() {
-				@Override
-				public void run() {
-					try {
-						final String[] urls = coverHelper.getCoverUrl(artist, album.getName(), null, null);
-						if (urls != null && urls.length > 0) {
-							int maxSize = albumCover.getLayoutParams().width;
-							if (maxSize == 0) {
-								// For some reason getWidth returned 0.
-								// It shouldn't do that with layoutparams but whatever.
-								// Use a fallback value. Better have a low quality image than nothing.
-								maxSize = 96;
-							}
-							final Bitmap cover = Tools.decodeSampledBitmapFromPath(urls[0], maxSize, maxSize, false);
-							if (cover != null) {
-								handler.post(new Runnable() {
-									@Override
-									public void run() {
-										final CoverBitmapDrawable myCover = new CoverBitmapDrawable(context.getResources(), cover);
-										albumCover.setImageDrawable(myCover);
-									}
-								});
-							}
-						}
-					} catch (Exception e) {
-					}
+
+		final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(app);
+
+		// display cover art in album listing if caching is on
+		if (this.artist != null && settings.getBoolean(CoverAsyncHelper.PREFERENCE_CACHE, true)) {
+			coverHelper = new CoverAsyncHelper(app, settings);
+			coverHelper.setCoverRetrieversFromPreferences();
+
+			// display a placeholder
+			ImageView albumCover = (ImageView) targetView.findViewById(R.id.albumCover);
+			int[] attrs = new int[] { R.attr.noCoverArtIcon };
+			final TypedArray ta = context.obtainStyledAttributes(attrs);
+			final Drawable drawableFromTheme = ta.getDrawable(0);
+			albumCover.setImageDrawable(drawableFromTheme);
+			ta.recycle();
+
+			coverHelper.addCoverDownloadListener(new AlbumCoverDownloadListener(albumCover));
+
+			boolean haveCachedArtwork = false;
+
+			try {
+				CachedCover cachedCover = new CachedCover(app);
+				final String[] urls = cachedCover.getCoverUrl(artist, album.getName(), null, null);
+				if(urls.length > 0) {
+					haveCachedArtwork = true;
 				}
-			}).start();
+			} catch (Exception e) {
+				// no cached artwork available
+			}
+
+			if(haveCachedArtwork == false && coverHelper.isWifi()) {
+				// proactively download and cache artwork
+				String filename = null;
+				String path = null;
+				List<? extends Item> songs = null;
+
+				try {
+					songs = app.oMPDAsyncHelper.oMPD.getSongs(new Artist(artist, 0), album);
+
+					if (songs.size() > 0) {
+						Music song = (Music) songs.get(0);
+						filename = song.getFilename();
+						path = song.getPath();
+						coverHelper.downloadCover(artist, album.getName(), path, filename);
+					}
+				} catch (MPDServerException e) {
+					// MPD error, bail on loading artwork
+					return;
+				}
+			}else{
+				coverHelper.downloadCover(artist, album.getName(), null, null);
+			}
+		}
+	}
+
+	private class AlbumCoverDownloadListener implements CoverDownloadListener {
+		ImageView albumCover;
+
+		public AlbumCoverDownloadListener(ImageView albumCover) {
+			this.albumCover = albumCover;
+			this.albumCover.setVisibility(View.VISIBLE);
+		}
+
+		@Override
+		public void onCoverDownloaded(Bitmap cover) {
+			if (albumCover == null) {
+				// The view is detached, bail.
+				cover.recycle();
+				return;
+			}
+			try {
+				// recycle the placeholder
+				final Drawable oldDrawable = albumCover.getDrawable();
+				if (oldDrawable != null && oldDrawable instanceof CoverBitmapDrawable) {
+					final Bitmap oldBitmap = ((CoverBitmapDrawable) oldDrawable).getBitmap();
+					if (oldBitmap != null)
+						oldBitmap.recycle();
+				}
+
+				if (cover != null) {
+					BitmapDrawable myCover = new CoverBitmapDrawable(context.getResources(), cover);
+					albumCover.setImageDrawable(myCover);
+				} else {
+					onCoverNotFound();
+				}
+			} catch (Exception e) {
+				// Just ignore
+			}
+		}
+
+		@Override
+		public void onCoverNotFound() {
+			// A placeholder is already shown so do nothing here
 		}
 	}
 


### PR DESCRIPTION
In the artist's album view, load cover art using the `CoverAsyncWorker`, instead of the custom code that was there.

This means we can load from the LAN or LastFM and cache artwork directly in that listing - instead of only in the album song listing.

Notes:
- You still have to have caching switched on to get any artwork loaded.
- The cached will be checked first to see if an image is present, before continuing to load from first LAN and then LastFM (builds on 2027f54b).
- I also check isWifi before downloading anything, so as not to overload a 3G connection

@abarisain I considered another config option to enable this feature, but I didn't as I know you don't want too many! The final item in the notes above was added to provide a sensible default, since there's no config option to switch this feature on.
