### PR TITLE
Robustness : Avoid crash due to NowPlayingFragment{421080e8} not attache...

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
@@ -136,6 +136,13 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
     }
 
     @Override
+    public void onDetach() {
+        super.onDetach();
+        this.activity = null;
+
+    }
+
+    @Override
     public void onDestroyView() {
         coverArt.setImageResource(R.drawable.no_cover_art);
         coverArtListener.freeCoverDrawable();


### PR DESCRIPTION
...d to Activity

 java.lang.IllegalStateException: Fragment NowPlayingFragment{421080e8} not attached to Activity
        at android.support.v4.app.Fragment.getResources(Fragment.java:579)
        at com.namelessdev.mpdroid.fragments.NowPlayingFragment$updateTrackInfoAsync.onPostExecute(NowPlayingFragment.java:563)
        at com.namelessdev.mpdroid.fragments.NowPlayingFragment$updateTrackInfoAsync.onPostExecute(NowPlayingFragment.java:520)
