### PR TITLE
Blacklist wrong cover & Go to current playlist song

### DIFF
--- a/MPDroid/res/values-de/strings.xml
+++ b/MPDroid/res/values-de/strings.xml
@@ -198,6 +198,7 @@
 	<string name="goToFolder">Gehe zum Verzeichnis</string>
 	<string name="goToStream">Gehe zu Streams</string>
     <string name="goToCurrent">Gehe zum aktuellen Song</string>
+    <string name="otherCover">Other image</string>
 
     <string name="actionSongSelected">1 Titel ausgewählt</string>
 	<string name="actionSongsSelected">%s Titel ausgewählt</string>

--- a/MPDroid/res/values-fr/strings.xml
+++ b/MPDroid/res/values-fr/strings.xml
@@ -185,6 +185,7 @@
     <string name="goToFolder">Aller au dossier</string>
     <string name="goToStream">Aller aux flux</string>
     <string name="goToCurrent">Aller à la chanson en cours</string>
+    <string name="otherCover">Autre image</string>
 
     <string name="actionSongSelected">1 chanson selectionnée</string>
     <string name="actionSongsSelected">%s chansons selectionnées</string>

--- a/MPDroid/res/values-ko/strings.xml
+++ b/MPDroid/res/values-ko/strings.xml
@@ -210,6 +210,7 @@
 	<string name="goToFolder">폴더로 가기</string>
 	<string name="goToStream">스트림으로 가기</string>
     <string name="goToCurrent">현재 곡으로 이동</string>
+    <string name="otherCover">기타 사진</string>
 
     <string name="actionSongSelected">한 곡이 선택됨</string>
 	<string name="actionSongsSelected">%s 곡이 선택됨</string>

--- a/MPDroid/res/values-uk/strings.xml
+++ b/MPDroid/res/values-uk/strings.xml
@@ -203,6 +203,7 @@
     <string name="goToFolder">Перейти до теки</string>
     <string name="goToStream">Перейти до потоків</string>
     <string name="goToCurrent">До поточної пісні</string>
+    <string name="otherCover">інша картина</string>
 
     <string name="actionSongSelected">Обрано 1 пісню</string>
     <string name="actionSongsSelected">Пісень обрано: %s</string>

--- a/MPDroid/res/values/strings.xml
+++ b/MPDroid/res/values/strings.xml
@@ -210,6 +210,7 @@
     <string name="goToFolder">Go to folder</string>
     <string name="goToStream">Go to streams</string>
     <string name="goToCurrent">Go to current song</string>
+    <string name="otherCover">Other image</string>
 
     <string name="actionSongSelected">1 song selected</string>
     <string name="actionSongsSelected">%s songs selected</string>

--- a/MPDroid/src/com/namelessdev/mpdroid/SettingsActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/SettingsActivity.java
@@ -1,70 +1,64 @@
 package com.namelessdev.mpdroid;
 
-import java.util.Collection;
-
+import android.app.AlertDialog;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.preference.*;
+import android.preference.Preference.OnPreferenceClickListener;
+import android.text.format.Formatter;
+import android.util.Log;
+import android.util.SparseArray;
+import android.view.Menu;
+import android.view.MenuItem;
+import com.namelessdev.mpdroid.cover.CachedCover;
+import com.namelessdev.mpdroid.helpers.CoverManager;
 import org.a0z.mpd.MPD;
 import org.a0z.mpd.MPDOutput;
 import org.a0z.mpd.MPDStatus;
 import org.a0z.mpd.event.StatusChangeListener;
 import org.a0z.mpd.exception.MPDServerException;
 
-import android.app.AlertDialog;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.os.Bundle;
-import android.os.Handler;
-import android.preference.CheckBoxPreference;
-import android.preference.EditTextPreference;
-import android.preference.Preference;
-import android.preference.Preference.OnPreferenceClickListener;
-import android.preference.PreferenceActivity;
-import android.preference.PreferenceCategory;
-import android.preference.PreferenceScreen;
-import android.text.format.Formatter;
-import android.util.Log;
-import android.util.SparseArray;
-import android.view.Menu;
-import android.view.MenuItem;
-
-import com.namelessdev.mpdroid.cover.CachedCover;
+import java.util.Collection;
 
 @SuppressWarnings("deprecation")
 public class SettingsActivity extends PreferenceActivity implements
-		StatusChangeListener {
+        StatusChangeListener {
 
-	private static final int MAIN = 0;
-	private static final int ADD = 1;
-	public static final String OPEN_OUTPUT = "open_output";
+    private static final int MAIN = 0;
+    private static final int ADD = 1;
+    public static final String OPEN_OUTPUT = "open_output";
 
-	private OnPreferenceClickListener onPreferenceClickListener;
-	private SparseArray<CheckBoxPreference> cbPrefs;
+    private OnPreferenceClickListener onPreferenceClickListener;
+    private SparseArray<CheckBoxPreference> cbPrefs;
 
-	private PreferenceScreen pOutputsScreen;
-	private PreferenceScreen pInformationScreen;
-	private Handler handler;
+    private PreferenceScreen pOutputsScreen;
+    private PreferenceScreen pInformationScreen;
+    private Handler handler;
 
-	private EditTextPreference pCacheUsage1;
- 	private	EditTextPreference pCacheUsage2;
+    private EditTextPreference pCacheUsage1;
+    private EditTextPreference pCacheUsage2;
 
-	@Override
-	public void onCreate(Bundle savedInstanceState) {
-		super.onCreate(savedInstanceState);
-		final MPDApplication app = (MPDApplication) getApplicationContext();
-		handler = new Handler();
-		addPreferencesFromResource(R.layout.settings);
-		// Log.i("MPDroid", "onCreate");
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final MPDApplication app = (MPDApplication) getApplicationContext();
+        handler = new Handler();
+        addPreferencesFromResource(R.layout.settings);
+        // Log.i("MPDroid", "onCreate");
 
-		onPreferenceClickListener = new OutputPreferenceClickListener();
-		cbPrefs = new SparseArray<CheckBoxPreference>();
-		pOutputsScreen = (PreferenceScreen) findPreference("outputsScreen");
-		pInformationScreen = (PreferenceScreen) findPreference("informationScreen");
-		PreferenceScreen pUpdate = (PreferenceScreen) findPreference("updateDB");
+        onPreferenceClickListener = new OutputPreferenceClickListener();
+        cbPrefs = new SparseArray<CheckBoxPreference>();
+        pOutputsScreen = (PreferenceScreen) findPreference("outputsScreen");
+        pInformationScreen = (PreferenceScreen) findPreference("informationScreen");
+        PreferenceScreen pUpdate = (PreferenceScreen) findPreference("updateDB");
 
-		// Use the ConnectionPreferConnectionPreferenceCategoryenceCategory for
-		// Wi-Fi based Connection setttings
+        // Use the ConnectionPreferConnectionPreferenceCategoryenceCategory for
+        // Wi-Fi based Connection setttings
 
 		/*
-		 * PreferenceScreen pConnectionScreen =
+         * PreferenceScreen pConnectionScreen =
 		 * (PreferenceScreen)findPreference("connectionScreen");
 		 * PreferenceCategory wifiConnection = new
 		 * ConnectionPreferenceCategory(this);
@@ -73,332 +67,333 @@ public class SettingsActivity extends PreferenceActivity implements
 		 * pConnectionScreen.addPreference(wifiConnection);
 		 */
 
-		if (!getResources().getBoolean(R.bool.isTablet)) {
-			final PreferenceCategory interfaceCategory = (PreferenceCategory) findPreference("category_interface");
-			interfaceCategory.removePreference(findPreference("tabletUI"));
-		}
+        if (!getResources().getBoolean(R.bool.isTablet)) {
+            final PreferenceCategory interfaceCategory = (PreferenceCategory) findPreference("category_interface");
+            interfaceCategory.removePreference(findPreference("tabletUI"));
+        }
 
-		final EditTextPreference pVersion = (EditTextPreference) findPreference("version");
-		final EditTextPreference pArtists = (EditTextPreference) findPreference("artists");
-		final EditTextPreference pAlbums = (EditTextPreference) findPreference("albums");
-		final EditTextPreference pSongs = (EditTextPreference) findPreference("songs");
+        final EditTextPreference pVersion = (EditTextPreference) findPreference("version");
+        final EditTextPreference pArtists = (EditTextPreference) findPreference("artists");
+        final EditTextPreference pAlbums = (EditTextPreference) findPreference("albums");
+        final EditTextPreference pSongs = (EditTextPreference) findPreference("songs");
 
-		// set the albumart fields
-		CheckBoxPreference c = (CheckBoxPreference) findPreference("enableLocalCover");
-		Preference mp = (Preference) findPreference("musicPath");
-		Preference cf = (Preference) findPreference("coverFileName");
-		if (c.isChecked()) {
-			mp.setEnabled(true);
-			cf.setEnabled(true);
-		} else {
-			mp.setEnabled(false);
-			cf.setEnabled(false);
-		}
+        // set the albumart fields
+        CheckBoxPreference c = (CheckBoxPreference) findPreference("enableLocalCover");
+        Preference mp = (Preference) findPreference("musicPath");
+        Preference cf = (Preference) findPreference("coverFileName");
+        if (c.isChecked()) {
+            mp.setEnabled(true);
+            cf.setEnabled(true);
+        } else {
+            mp.setEnabled(false);
+            cf.setEnabled(false);
+        }
 
-		// artwork cache usage
-		long size = new CachedCover(app).getCacheUsage();
-		String usage = Formatter.formatFileSize(app, size);
-		pCacheUsage1 = (EditTextPreference) findPreference("cacheUsage1");
-		pCacheUsage1.setSummary(usage);
-		pCacheUsage2 = (EditTextPreference) findPreference("cacheUsage2");
-		pCacheUsage2.setSummary(usage);
+        // artwork cache usage
+        long size = new CachedCover(app).getCacheUsage();
+        String usage = Formatter.formatFileSize(app, size);
+        pCacheUsage1 = (EditTextPreference) findPreference("cacheUsage1");
+        pCacheUsage1.setSummary(usage);
+        pCacheUsage2 = (EditTextPreference) findPreference("cacheUsage2");
+        pCacheUsage2.setSummary(usage);
 
-		// album art library listing requires cover art cache
-		CheckBoxPreference lcc = (CheckBoxPreference) findPreference("enableLocalCoverCache");
-		CheckBoxPreference aal = (CheckBoxPreference) findPreference("enableAlbumArtLibrary");
-		aal.setEnabled(lcc.isChecked());
+        // album art library listing requires cover art cache
+        CheckBoxPreference lcc = (CheckBoxPreference) findPreference("enableLocalCoverCache");
+        CheckBoxPreference aal = (CheckBoxPreference) findPreference("enableAlbumArtLibrary");
+        aal.setEnabled(lcc.isChecked());
 
-		// Enable/Disable playback resume when call ends only if playback pause
-		// is enabled when call starts
-		CheckBoxPreference cPause = (CheckBoxPreference) findPreference("pauseOnPhoneStateChange");
-		CheckBoxPreference cPlay = (CheckBoxPreference) findPreference("playOnPhoneStateChange");
-		cPlay.setEnabled(cPause.isChecked());
+        // Enable/Disable playback resume when call ends only if playback pause
+        // is enabled when call starts
+        CheckBoxPreference cPause = (CheckBoxPreference) findPreference("pauseOnPhoneStateChange");
+        CheckBoxPreference cPlay = (CheckBoxPreference) findPreference("playOnPhoneStateChange");
+        cPlay.setEnabled(cPause.isChecked());
 
-		if (!app.oMPDAsyncHelper.oMPD.isConnected()) {
-			pOutputsScreen.setEnabled(false);
-			pUpdate.setEnabled(false);
-			pInformationScreen.setEnabled(false);
-			return;
-		}
-		app.oMPDAsyncHelper.addStatusChangeListener(this);
+        if (!app.oMPDAsyncHelper.oMPD.isConnected()) {
+            pOutputsScreen.setEnabled(false);
+            pUpdate.setEnabled(false);
+            pInformationScreen.setEnabled(false);
+            return;
+        }
+        app.oMPDAsyncHelper.addStatusChangeListener(this);
 
-		new Thread(new Runnable() {
+        new Thread(new Runnable() {
 
-			@Override
-			public void run() {
-				try {
-					final String version = app.oMPDAsyncHelper.oMPD
-							.getMpdVersion();
-					final String artists = ""
-							+ app.oMPDAsyncHelper.oMPD.getStatistics()
-									.getArtists();
-					final String albums = ""
-							+ app.oMPDAsyncHelper.oMPD.getStatistics()
-									.getAlbums();
-					final String songs = ""
-							+ app.oMPDAsyncHelper.oMPD.getStatistics()
-									.getSongs();
-					handler.post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    final String version = app.oMPDAsyncHelper.oMPD
+                            .getMpdVersion();
+                    final String artists = ""
+                            + app.oMPDAsyncHelper.oMPD.getStatistics()
+                            .getArtists();
+                    final String albums = ""
+                            + app.oMPDAsyncHelper.oMPD.getStatistics()
+                            .getAlbums();
+                    final String songs = ""
+                            + app.oMPDAsyncHelper.oMPD.getStatistics()
+                            .getSongs();
+                    handler.post(new Runnable() {
 
-						@Override
-						public void run() {
-							pVersion.setSummary(version);
-							pArtists.setSummary(artists);
-							pAlbums.setSummary(albums);
-							pSongs.setSummary(songs);
-						}
-					});
-				} catch (MPDServerException e) {
-					// TODO Auto-generated catch block
-					// e.printStackTrace();
-				}
-			}
-		}).start();
-		// Server is Connected...
+                        @Override
+                        public void run() {
+                            pVersion.setSummary(version);
+                            pArtists.setSummary(artists);
+                            pAlbums.setSummary(albums);
+                            pSongs.setSummary(songs);
+                        }
+                    });
+                } catch (MPDServerException e) {
+                    // TODO Auto-generated catch block
+                    // e.printStackTrace();
+                }
+            }
+        }).start();
+        // Server is Connected...
 
-		if (getIntent().getBooleanExtra(OPEN_OUTPUT, false)) {
-			populateOutputsScreen();
-			setPreferenceScreen(pOutputsScreen);
-		}
-	}
+        if (getIntent().getBooleanExtra(OPEN_OUTPUT, false)) {
+            populateOutputsScreen();
+            setPreferenceScreen(pOutputsScreen);
+        }
+    }
 
-	@Override
-	protected void onStart() {
-		super.onStart();
-		MPDApplication app = (MPDApplication) getApplicationContext();
-		app.setActivity(this);
-	}
+    @Override
+    protected void onStart() {
+        super.onStart();
+        MPDApplication app = (MPDApplication) getApplicationContext();
+        app.setActivity(this);
+    }
 
-	@Override
-	protected void onStop() {
-		super.onStop();
-		MPDApplication app = (MPDApplication) getApplicationContext();
-		app.unsetActivity(this);
-	}
+    @Override
+    protected void onStop() {
+        super.onStop();
+        MPDApplication app = (MPDApplication) getApplicationContext();
+        app.unsetActivity(this);
+    }
 
-	@Override
-	protected void onDestroy() {
-		MPDApplication app = (MPDApplication) getApplicationContext();
-		app.oMPDAsyncHelper.removeStatusChangeListener(this);
-		super.onDestroy();
-	}
+    @Override
+    protected void onDestroy() {
+        MPDApplication app = (MPDApplication) getApplicationContext();
+        app.oMPDAsyncHelper.removeStatusChangeListener(this);
+        super.onDestroy();
+    }
 
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		boolean result = super.onCreateOptionsMenu(menu);
-		if (getPreferenceScreen().getKey().equals("connectionscreen"))
-			menu.add(0, ADD, 1, R.string.clear).setIcon(
-					android.R.drawable.ic_menu_add);
-		return result;
-	}
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        boolean result = super.onCreateOptionsMenu(menu);
+        if (getPreferenceScreen().getKey().equals("connectionscreen"))
+            menu.add(0, ADD, 1, R.string.clear).setIcon(
+                    android.R.drawable.ic_menu_add);
+        return result;
+    }
 
-	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
 
-		Intent i = null;
+        Intent i = null;
 
-		switch (item.getItemId()) {
+        switch (item.getItemId()) {
 
-		case MAIN:
-			i = new Intent(this, MainMenuActivity.class);
-			i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-			startActivity(i);
-			return true;
-		}
-		return false;
-	}
+            case MAIN:
+                i = new Intent(this, MainMenuActivity.class);
+                i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                startActivity(i);
+                return true;
+        }
+        return false;
+    }
 
-	/**
-	 * Method is beeing called on any click of an preference...
-	 */
+    /**
+     * Method is beeing called on any click of an preference...
+     */
 
-	public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen,
-			Preference preference) {
-		Log.d("MPDroid", preferenceScreen.getKey());
-		MPDApplication app = (MPDApplication) getApplication();
+    public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen,
+                                         Preference preference) {
+        Log.d("MPDroid", preferenceScreen.getKey());
+        MPDApplication app = (MPDApplication) getApplication();
 
-		// Is it the connectionscreen which is called?
-		if (preference.getKey() == null)
-			return false;
+        // Is it the connectionscreen which is called?
+        if (preference.getKey() == null)
+            return false;
 
-		if (preference.getKey().equals("outputsScreen")) {
-			populateOutputsScreen();
-			return true;
+        if (preference.getKey().equals("outputsScreen")) {
+            populateOutputsScreen();
+            return true;
 
-		} else if (preference.getKey().equals("updateDB")) {
-			try {
-				MPD oMPD = app.oMPDAsyncHelper.oMPD;
-				oMPD.refreshDatabase();
-			} catch (MPDServerException e) {
-			}
-			return true;
+        } else if (preference.getKey().equals("updateDB")) {
+            try {
+                MPD oMPD = app.oMPDAsyncHelper.oMPD;
+                oMPD.refreshDatabase();
+            } catch (MPDServerException e) {
+            }
+            return true;
 
-		} else if (preference.getKey().equals("clearLocalCoverCache")) {
-			new AlertDialog.Builder(this)
-					.setTitle(R.string.clearLocalCoverCache)
-					.setMessage(R.string.clearLocalCoverCachePrompt)
-					.setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-						public void onClick(DialogInterface dialog, int which) {
-							MPDApplication app = (MPDApplication) getApplication();
-							new CachedCover(app).clear();
-							pCacheUsage1.setSummary("0.00B");
-							pCacheUsage2.setSummary("0.00B");
-						}
-					})
-					.setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
-						public void onClick(DialogInterface dialog, int which) {
-							// do nothing
-						}
-					})
-					.show();
-			return true;
+        } else if (preference.getKey().equals("clearLocalCoverCache")) {
+            new AlertDialog.Builder(this)
+                    .setTitle(R.string.clearLocalCoverCache)
+                    .setMessage(R.string.clearLocalCoverCachePrompt)
+                    .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            MPDApplication app = (MPDApplication) getApplication();
+                            // Todo : The covermanager must already have been initialized, get rid of the getInstance arguments
+                            CoverManager.getInstance(app, null).clear();
+                            pCacheUsage1.setSummary("0.00B");
+                            pCacheUsage2.setSummary("0.00B");
+                        }
+                    })
+                    .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            // do nothing
+                        }
+                    })
+                    .show();
+            return true;
 
-		} else if (preference.getKey().equals("enableLocalCover")) {
-			CheckBoxPreference c = (CheckBoxPreference) findPreference("enableLocalCover");
-			Preference mp = (Preference) findPreference("musicPath");
-			Preference cf = (Preference) findPreference("coverFileName");
+        } else if (preference.getKey().equals("enableLocalCover")) {
+            CheckBoxPreference c = (CheckBoxPreference) findPreference("enableLocalCover");
+            Preference mp = (Preference) findPreference("musicPath");
+            Preference cf = (Preference) findPreference("coverFileName");
 
-			if (c.isChecked()) {
-				mp.setEnabled(true);
-				cf.setEnabled(true);
-			} else {
-				mp.setEnabled(false);
-				cf.setEnabled(false);
-			}
-			return true;
+            if (c.isChecked()) {
+                mp.setEnabled(true);
+                cf.setEnabled(true);
+            } else {
+                mp.setEnabled(false);
+                cf.setEnabled(false);
+            }
+            return true;
 
-		} else if (preference.getKey().equals("enableLocalCoverCache")) {
-			// album art library listing requires cover art cache
-			CheckBoxPreference lcc = (CheckBoxPreference) findPreference("enableLocalCoverCache");
-			CheckBoxPreference aal = (CheckBoxPreference) findPreference("enableAlbumArtLibrary");
-			if (lcc.isChecked()) {
-				aal.setEnabled(true);
-			}else{
-				aal.setEnabled(false);
-				aal.setChecked(false);
-			}
-			return true;
+        } else if (preference.getKey().equals("enableLocalCoverCache")) {
+            // album art library listing requires cover art cache
+            CheckBoxPreference lcc = (CheckBoxPreference) findPreference("enableLocalCoverCache");
+            CheckBoxPreference aal = (CheckBoxPreference) findPreference("enableAlbumArtLibrary");
+            if (lcc.isChecked()) {
+                aal.setEnabled(true);
+            } else {
+                aal.setEnabled(false);
+                aal.setChecked(false);
+            }
+            return true;
 
-		} else if (preference.getKey().equals("pauseOnPhoneStateChange")) {
-			// Enable/Disable playback resume when call ends only if playback
-			// pause is enabled when call starts
-			CheckBoxPreference cPause = (CheckBoxPreference) findPreference("pauseOnPhoneStateChange");
-			CheckBoxPreference c = (CheckBoxPreference) findPreference("playOnPhoneStateChange");
-			c.setEnabled(cPause.isChecked());
-		}
-		return false;
+        } else if (preference.getKey().equals("pauseOnPhoneStateChange")) {
+            // Enable/Disable playback resume when call ends only if playback
+            // pause is enabled when call starts
+            CheckBoxPreference cPause = (CheckBoxPreference) findPreference("pauseOnPhoneStateChange");
+            CheckBoxPreference c = (CheckBoxPreference) findPreference("playOnPhoneStateChange");
+            c.setEnabled(cPause.isChecked());
+        }
+        return false;
 
-	}
+    }
 
-	private void populateOutputsScreen() {
-		// Populating outputs...
-		PreferenceCategory pOutput = (PreferenceCategory) findPreference("outputsCategory");
-		final MPDApplication app = (MPDApplication) getApplication();
-		try {
-			Collection<MPDOutput> list = app.oMPDAsyncHelper.oMPD.getOutputs();
+    private void populateOutputsScreen() {
+        // Populating outputs...
+        PreferenceCategory pOutput = (PreferenceCategory) findPreference("outputsCategory");
+        final MPDApplication app = (MPDApplication) getApplication();
+        try {
+            Collection<MPDOutput> list = app.oMPDAsyncHelper.oMPD.getOutputs();
 
-			pOutput.removeAll();
-			for (MPDOutput out : list) {
-				CheckBoxPreference pref = new CheckBoxPreference(this);
-				pref.setPersistent(false);
-				pref.setTitle(out.getName());
-				pref.setChecked(out.isEnabled());
-				pref.setKey("" + out.getId());
-				pref.setOnPreferenceClickListener(onPreferenceClickListener);
-				cbPrefs.put(out.getId(), pref);
-				pOutput.addPreference(pref);
+            pOutput.removeAll();
+            for (MPDOutput out : list) {
+                CheckBoxPreference pref = new CheckBoxPreference(this);
+                pref.setPersistent(false);
+                pref.setTitle(out.getName());
+                pref.setChecked(out.isEnabled());
+                pref.setKey("" + out.getId());
+                pref.setOnPreferenceClickListener(onPreferenceClickListener);
+                cbPrefs.put(out.getId(), pref);
+                pOutput.addPreference(pref);
 
-			}
-		} catch (MPDServerException e) {
-			pOutput.removeAll(); // Connection error occured meanwhile...
-		}
-	}
+            }
+        } catch (MPDServerException e) {
+            pOutput.removeAll(); // Connection error occured meanwhile...
+        }
+    }
 
-	class CheckPreferenceClickListener implements OnPreferenceClickListener {
-		MPDApplication app = (MPDApplication) getApplication();
+    class CheckPreferenceClickListener implements OnPreferenceClickListener {
+        MPDApplication app = (MPDApplication) getApplication();
 
-		@Override
-		public boolean onPreferenceClick(Preference pref) {
-			CheckBoxPreference prefCB = (CheckBoxPreference) pref;
-			MPD oMPD = app.oMPDAsyncHelper.oMPD;
-			try {
-				if (prefCB.getKey().equals("random"))
-					oMPD.setRandom(prefCB.isChecked());
-				if (prefCB.getKey().equals("repeat"))
-					oMPD.setRepeat(prefCB.isChecked());
-				return prefCB.isChecked();
-			} catch (MPDServerException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			return false;
-		}
+        @Override
+        public boolean onPreferenceClick(Preference pref) {
+            CheckBoxPreference prefCB = (CheckBoxPreference) pref;
+            MPD oMPD = app.oMPDAsyncHelper.oMPD;
+            try {
+                if (prefCB.getKey().equals("random"))
+                    oMPD.setRandom(prefCB.isChecked());
+                if (prefCB.getKey().equals("repeat"))
+                    oMPD.setRepeat(prefCB.isChecked());
+                return prefCB.isChecked();
+            } catch (MPDServerException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+            return false;
+        }
 
-	}
+    }
 
-	class OutputPreferenceClickListener implements OnPreferenceClickListener {
-		@Override
-		public boolean onPreferenceClick(Preference pref) {
-			CheckBoxPreference prefCB = (CheckBoxPreference) pref;
-			MPDApplication app = (MPDApplication) getApplication();
-			MPD oMPD = app.oMPDAsyncHelper.oMPD;
-			String id = prefCB.getKey();
-			try {
-				if (prefCB.isChecked()) {
-					oMPD.enableOutput(Integer.parseInt(id));
-					return false;
-				} else {
-					oMPD.disableOutput(Integer.parseInt(id));
-					return true;
-				}
-			} catch (MPDServerException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-			return true;
-		}
-	}
+    class OutputPreferenceClickListener implements OnPreferenceClickListener {
+        @Override
+        public boolean onPreferenceClick(Preference pref) {
+            CheckBoxPreference prefCB = (CheckBoxPreference) pref;
+            MPDApplication app = (MPDApplication) getApplication();
+            MPD oMPD = app.oMPDAsyncHelper.oMPD;
+            String id = prefCB.getKey();
+            try {
+                if (prefCB.isChecked()) {
+                    oMPD.enableOutput(Integer.parseInt(id));
+                    return false;
+                } else {
+                    oMPD.disableOutput(Integer.parseInt(id));
+                    return true;
+                }
+            } catch (MPDServerException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+            return true;
+        }
+    }
 
-	@Override
-	public void volumeChanged(MPDStatus mpdStatus, int oldVolume) {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void volumeChanged(MPDStatus mpdStatus, int oldVolume) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void playlistChanged(MPDStatus mpdStatus, int oldPlaylistVersion) {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void playlistChanged(MPDStatus mpdStatus, int oldPlaylistVersion) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void trackChanged(MPDStatus mpdStatus, int oldTrack) {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void trackChanged(MPDStatus mpdStatus, int oldTrack) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void stateChanged(MPDStatus mpdStatus, String oldState) {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void stateChanged(MPDStatus mpdStatus, String oldState) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void repeatChanged(boolean repeating) {
-	}
+    @Override
+    public void repeatChanged(boolean repeating) {
+    }
 
-	@Override
-	public void randomChanged(boolean random) {
-	}
+    @Override
+    public void randomChanged(boolean random) {
+    }
 
-	@Override
-	public void connectionStateChanged(boolean connected, boolean connectionLost) {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void connectionStateChanged(boolean connected, boolean connectionLost) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void libraryStateChanged(boolean updating) {
-		// TODO Auto-generated method stub
-	}
+    @Override
+    public void libraryStateChanged(boolean updating) {
+        // TODO Auto-generated method stub
+    }
 
-	@Override
-	public void onBackPressed() {
-		super.onBackPressed();
-	}
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+    }
 }

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/CachedCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/CachedCover.java
@@ -2,124 +2,143 @@ package com.namelessdev.mpdroid.cover;
 
 import android.graphics.Bitmap;
 import android.os.Environment;
-import android.util.Log;
 import com.namelessdev.mpdroid.MPDApplication;
-import com.namelessdev.mpdroid.tools.Tools;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import static android.util.Log.d;
+import static android.util.Log.e;
+import static com.namelessdev.mpdroid.helpers.CoverManager.getCoverFileName;
+
 public class CachedCover implements ICoverRetriever {
 
-	private MPDApplication application;
-	private static final String FOLDER_SUFFIX = "/covers/";
+    private MPDApplication application;
+    private static final String FOLDER_SUFFIX = "/covers/";
 
-	public CachedCover(MPDApplication context) {
-		if (context == null)
-			throw new RuntimeException("Context cannot be null");
-		application = context;
-	}
+    public CachedCover(MPDApplication context) {
+        if (context == null)
+            throw new RuntimeException("Context cannot be null");
+        application = context;
+    }
 
-	@Override
-	public String[] getCoverUrl(String artist, String album, String path, String filename) throws Exception {
-		final String storageState = Environment.getExternalStorageState();
-		// If there is no external storage available, don't bother
-		if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(storageState) || Environment.MEDIA_MOUNTED.equals(storageState)) {
-			final String url = getAbsolutePathForSong(artist, album);
-			if (new File(url).exists())
-				return new String[] { url };
-		}
-		return null;
-	}
+    @Override
+    public String[] getCoverUrl(String artist, String album, String path, String filename) throws Exception {
+        final String storageState = Environment.getExternalStorageState();
+        // If there is no external storage available, don't bother
+        if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(storageState) || Environment.MEDIA_MOUNTED.equals(storageState)) {
+            final String url = getAbsolutePathForSong(artist, album);
+            if (new File(url).exists())
+                return new String[]{url};
+        }
+        return null;
+    }
 
-	@Override
-	public boolean isCoverLocal() {
-		return true;
-	}
+    @Override
+    public boolean isCoverLocal() {
+        return true;
+    }
 
-	@Override
-	public String getName() {
-		return "SD Card Cache";
-	}
+    @Override
+    public String getName() {
+        return "SD Card Cache";
+    }
 
-	public long getCacheUsage() {
-		long size = 0;
-		final String cacheDir = getAbsoluteCoverFolderPath();
-		if (null != cacheDir && 0 != cacheDir.length()) {
-			File[] files = new File(cacheDir).listFiles();
-			if (null != files) {
-				for (File file : files) {
-					if (file.isFile()) {
-						size += file.length();
-					}
-				}
-			}
-		}
-		return size;
-	}
+    public long getCacheUsage() {
+        long size = 0;
+        final String cacheDir = getAbsoluteCoverFolderPath();
+        if (null != cacheDir && 0 != cacheDir.length()) {
+            File[] files = new File(cacheDir).listFiles();
+            if (null != files) {
+                for (File file : files) {
+                    if (file.isFile()) {
+                        size += file.length();
+                    }
+                }
+            }
+        }
+        return size;
+    }
 
-	public void save(String artist, String album, Bitmap cover) {
-		if (!Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {
-			// External storage is not there or read only, don't do anything
-			Log.e(MPDApplication.TAG, "No writable external storage, not saving cover to cache");
-			return;
-		}
+    public void save(String artist, String album, Bitmap cover) {
+        if (!Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState())) {
+            // External storage is not there or read only, don't do anything
+            e(MPDApplication.TAG, "No writable external storage, not saving cover to cache");
+            return;
+        }
         FileOutputStream out = null;
-		try {
-			new File(getAbsoluteCoverFolderPath()).mkdirs();
-			out = new FileOutputStream(getAbsolutePathForSong(artist, album));
-			cover.compress(Bitmap.CompressFormat.JPEG, 95, out);
-		} catch (Exception e) {
-            Log.e(MPDApplication.TAG, "Cache cover write failure : " + e);
-		}
-        finally {
+        try {
+            new File(getAbsoluteCoverFolderPath()).mkdirs();
+            out = new FileOutputStream(getAbsolutePathForSong(artist, album));
+            cover.compress(Bitmap.CompressFormat.JPEG, 95, out);
+        } catch (Exception e) {
+            e(MPDApplication.TAG, "Cache cover write failure : " + e);
+        } finally {
             if (out != null) {
                 try {
                     out.close();
                 } catch (IOException e) {
-                    Log.e(MPDApplication.TAG, "Cannot close cover stream : " + e);
+                    e(MPDApplication.TAG, "Cannot close cover stream : " + e);
                 }
             }
         }
     }
 
-	public void clear() {
-		final String cacheFolderPath = getAbsoluteCoverFolderPath();
-		if (cacheFolderPath == null)
-			return;
-		final File cacheFolder = new File(cacheFolderPath);
-		if (!cacheFolder.exists()) {
-			return;
-		}
-		File[] files = cacheFolder.listFiles();
-		if (files != null) {
-			for (File f : files) {
-				// No need to take care of subfolders, there won't be any.
-				// (Or at least any that MPDroid cares about)
-				f.delete();
-			}
-		}
-	}
+    public void clear() {
+        final String cacheFolderPath = getAbsoluteCoverFolderPath();
+        if (cacheFolderPath == null)
+            return;
+        final File cacheFolder = new File(cacheFolderPath);
+        if (!cacheFolder.exists()) {
+            return;
+        }
+        File[] files = cacheFolder.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                // No need to take care of subfolders, there won't be any.
+                // (Or at least any that MPDroid cares about)
+                f.delete();
+            }
+        }
+    }
 
-	public String getAbsoluteCoverFolderPath() {
-		final File cacheDir = application.getExternalCacheDir();
-		if (cacheDir == null)
-			return null;
-		return cacheDir.getAbsolutePath() + FOLDER_SUFFIX;
-	}
+    public void delete(String artist, String album) {
+        d(CachedCover.class.getSimpleName(), "Deleting cover for : " + artist + ", " + album);
 
-	public String getAbsolutePathForSong(String artist, String album) {
-		final File cacheDir = application.getExternalCacheDir();
-		if (cacheDir == null)
-			return null;
-		String filename;
-		if (artist != null) {
-			filename = Tools.getHashFromString(artist + ";" + album) + ".jpg";
-		}else{
-			filename = Tools.getHashFromString(album) + ".jpg";
-		}
-		return getAbsoluteCoverFolderPath() + filename;
-	}
+        final String cacheFolderPath = getAbsoluteCoverFolderPath();
+        if (cacheFolderPath == null)
+            return;
+        final File cacheFolder = new File(cacheFolderPath);
+        if (!cacheFolder.exists()) {
+            return;
+        }
+        File[] files = cacheFolder.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                // No need to take care of subfolders, there won't be any.
+                // (Or at least any that MPDroid cares about)
+                if (getCoverFileName(artist, album).equals(f.getName())) {
+                    d(CachedCover.class.getSimpleName(), "Deleting cover : " + f.getName());
+                    f.delete();
+                }
+            }
+        }
+    }
+
+    public String getAbsoluteCoverFolderPath() {
+        final File cacheDir = application.getExternalCacheDir();
+        if (cacheDir == null)
+            return null;
+        return cacheDir.getAbsolutePath() + FOLDER_SUFFIX;
+    }
+
+    public String getAbsolutePathForSong(String artist, String album) {
+        final File cacheDir = application.getExternalCacheDir();
+        if (cacheDir == null)
+            return null;
+        return getAbsoluteCoverFolderPath() + getCoverFileName(artist, album);
+    }
+
 
 }

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingSmallFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingSmallFragment.java
@@ -270,7 +270,7 @@ public class NowPlayingSmallFragment extends Fragment implements StatusChangeLis
 					coverArtListener.onCoverNotFound(new CoverInfo(artist,album));
 				} else if (!lastAlbum.equals(album) || !lastArtist.equals(artist)) {
 					coverArtProgress.setVisibility(ProgressBar.VISIBLE);
-                    coverArt.setTag(CoverManager.getCoverArtTag(artist, album));
+                    coverArt.setTag(CoverManager.getAlbumKey(artist, album));
                     coverHelper.downloadCover(artist, album, actSong.getPath(), actSong.getFilename());
 					lastArtist = artist;
 					lastAlbum = album;

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/PlaylistFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/PlaylistFragment.java
@@ -226,7 +226,7 @@ public class PlaylistFragment extends ListFragment implements StatusChangeListen
         }
     }
 
-    protected void update() {
+    public void update() {
         update(true);
     }
 
@@ -633,7 +633,7 @@ public class PlaylistFragment extends ListFragment implements StatusChangeListen
             String filename = (String) item.get("_filename");
 
 
-            String viewTag = CoverManager.getPlaylistCoverTag(artist, album, title);
+            String viewTag = CoverManager.getPlaylistItemKey(artist, album, title);
             if (view.getTag() == null || !view.getTag().equals(viewTag)) {
                 view.setTag(viewTag);
                 view.findViewById(R.id.icon).setVisibility(filter == null ? View.VISIBLE : View.GONE);
@@ -658,7 +658,7 @@ public class PlaylistFragment extends ListFragment implements StatusChangeListen
 
                 albumCover.setTag(R.id.AlbumCoverDownloadListener, acd);
                 coverHelper.addCoverDownloadListener(acd);
-                albumCover.setTag(CoverManager.getCoverArtTag(artist, album));
+                albumCover.setTag(CoverManager.getAlbumKey(artist, album));
                 coverHelper.downloadCover(artist, album, path, filename, false, cacheOnly);
             }
             return view;

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/SongsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/SongsFragment.java
@@ -260,7 +260,7 @@ public class SongsFragment extends BrowseFragment {
 					artistName = song.getArtist();
 				}
 				coverArtProgress.setVisibility(ProgressBar.VISIBLE);
-                coverArt.setTag(CoverManager.getCoverArtTag(artistName, album.getName()));
+                coverArt.setTag(CoverManager.getAlbumKey(artistName, album.getName()));
                 coverHelper.downloadCover(artistName, album.getName(), path, filename);
 			} else {
 				coverArtListener.onCoverNotFound(new CoverInfo(artistName,album.getName()));

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/AlbumCoverDownloadListener.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/AlbumCoverDownloadListener.java
@@ -44,7 +44,7 @@ public class AlbumCoverDownloadListener implements CoverDownloadListener {
             return;
         try {
 
-            if (coverArt.getTag() == null || coverArt.getTag().equals(CoverManager.getCoverArtTag(cover.getArtist() , cover.getAlbum()))) {
+            if (coverArt.getTag() == null || coverArt.getTag().equals(CoverManager.getAlbumKey(cover.getArtist(), cover.getAlbum()))) {
                 if (coverArtProgress != null) {
                     coverArtProgress.setVisibility(ProgressBar.INVISIBLE);
                 }
@@ -62,11 +62,11 @@ public class AlbumCoverDownloadListener implements CoverDownloadListener {
         if (cover == null || coverArt == null)
             return;
 
-        if (coverArt.getTag() == null || coverArt.getTag().equals(CoverManager.getCoverArtTag(cover.getArtist() , cover.getAlbum()))) {
+        if (coverArt.getTag() == null || coverArt.getTag().equals(CoverManager.getAlbumKey(cover.getArtist(), cover.getAlbum()))) {
 
             cover.setBitmap(null);
 
-            if (coverArt.getTag() == null || coverArt.getTag().equals(CoverManager.getCoverArtTag(cover.getArtist() , cover.getAlbum()))) {
+            if (coverArt.getTag() == null || coverArt.getTag().equals(CoverManager.getAlbumKey(cover.getArtist(), cover.getAlbum()))) {
                 if (coverArtProgress != null)
                     coverArtProgress.setVisibility(ProgressBar.INVISIBLE);
                 if (coverArt != null) {

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/MultiMap.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/MultiMap.java
@@ -15,12 +15,13 @@
  */
 package com.namelessdev.mpdroid.tools;
 
+import java.io.Serializable;
 import java.util.*;
 
 /**
  * A {@link Map} that supports multiple values per key.
  */
-public class MultiMap<K, V> {
+public class MultiMap<K, V> implements Serializable {
 
     private final Map<K, List<V>> mInternalMap;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/AlbumDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/AlbumDataBinder.java
@@ -71,7 +71,7 @@ public class AlbumDataBinder extends BaseDataBinder {
 
 			holder.albumCover.setTag(R.id.AlbumCoverDownloadListener, acd);
 			coverHelper.addCoverDownloadListener(acd);
-            holder.albumCover.setTag(CoverManager.getCoverArtTag(artist,album.getName()));
+            holder.albumCover.setTag(CoverManager.getAlbumKey(artist, album.getName()));
             loadArtwork(coverHelper, artist, album.getName());
 		}
 	}

--- a/MPDroid/src/com/namelessdev/mpdroid/views/AlbumGridDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/AlbumGridDataBinder.java
@@ -51,7 +51,7 @@ public class AlbumGridDataBinder extends AlbumDataBinder {
 
         // Can't get artwork for missing album name
         if (CoverManager.isValidArtistOrAlbum(album.getArtist().getName()) && CoverManager.isValidArtistOrAlbum(album.getName()) && enableCache) {
-            holder.albumCover.setTag(CoverManager.getCoverArtTag(album.getArtist().getName() , album.getName()));
+            holder.albumCover.setTag(CoverManager.getAlbumKey(album.getArtist().getName(), album.getName()));
             loadArtwork(coverHelper, album.getArtist().getName(), album.getName());
         }
     }

--- a/MPDroid/src/com/namelessdev/mpdroid/views/StoredPlaylistDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/StoredPlaylistDataBinder.java
@@ -75,7 +75,7 @@ public class StoredPlaylistDataBinder extends BaseDataBinder {
 				oldAcd.detach();
 			holder.cover.setTag(R.id.AlbumCoverDownloadListener, acd);
 			coverHelper.addCoverDownloadListener(acd);
-            holder.cover.setTag(CoverManager.getCoverArtTag(artist, album));
+            holder.cover.setTag(CoverManager.getAlbumKey(artist, album));
             loadArtwork(coverHelper, artist, album);
 		}
 	}


### PR DESCRIPTION
- A touch on the album cover displays the current song in the playlist. (also an entry in the nowplaying popup menu does the same thing)
- A long touch on the album cover displays a menu in which you can blacklist the current cover, a new one is then downloaded. The playlist is also updated.

Better to clean your existing album cover cache to test this update.
