### PR TITLE
Always show fast scroll for 4.4

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/BrowseFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/BrowseFragment.java
@@ -96,6 +96,8 @@ public abstract class BrowseFragment extends Fragment implements OnMenuItemClick
 		list = (ListView) view.findViewById(R.id.list);
 		registerForContextMenu(list);
 		list.setOnItemClickListener(this);
+		if (android.os.Build.VERSION.SDK_INT == 19)
+			list.setFastScrollAlwaysVisible(true);
 		loadingView = view.findViewById(R.id.loadingLayout);
 		loadingTextView = (TextView) view.findViewById(R.id.loadingText);
 		noResultView = view.findViewById(R.id.noResultLayout);


### PR DESCRIPTION
Workaround for fast scroll not being visible on 4.4 devices. Fixes issue #294, for now at least. Hopefully 4.4.1 fixes this for good.
