### PR TITLE
Fix for fatal exception in now playing fragment go to folder

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
@@ -918,7 +918,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
                     break;
                 }
                 intent = new Intent(activity, SimpleLibraryActivity.class);
-                intent.putExtra("folder", currentSong.getParent());
+                intent.putExtra("folder", parent);
                 startActivityForResult(intent, -1);
                 break;
             case POPUP_CURRENT:


### PR DESCRIPTION
Spotify tracks have a path but don't have a parent folder so MPDroid crashes with the following stack trace when using 'go to folder' from the now playing fragment.  This probably only applies to mopidy users but I think it's a reasonable fix.

```
12-15 16:05:40.840  8427  8427 E AndroidRuntime: FATAL EXCEPTION: main
12-15 16:05:40.840  8427  8427 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{com.namelessdev.mpdroid/com.namelessdev.mpdroid.library.SimpleLibraryActivity}: java.lang.RuntimeException: Error : cannot start SimpleLibraryActivity without an extra
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2228)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2288)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.ActivityThread.access$600(ActivityThread.java:148)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1273)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.os.Handler.dispatchMessage(Handler.java:99)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.os.Looper.loop(Looper.java:137)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.ActivityThread.main(ActivityThread.java:5222)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at java.lang.reflect.Method.invokeNative(Native Method)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at java.lang.reflect.Method.invoke(Method.java:525)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:737)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at dalvik.system.NativeStart.main(Native Method)
12-15 16:05:40.840  8427  8427 E AndroidRuntime: Caused by: java.lang.RuntimeException: Error : cannot start SimpleLibraryActivity without an extra
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at com.namelessdev.mpdroid.library.SimpleLibraryActivity.onCreate(SimpleLibraryActivity.java:71)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.Activity.performCreate(Activity.java:5150)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1087)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2192)
12-15 16:05:40.840  8427  8427 E AndroidRuntime:    ... 11 more
12-15 16:05:40.850   875  1793 W ActivityManager:   Force finishing activity com.namelessdev.mpdroid/.library.SimpleLibraryActivity
12-15 16:05:40.852   875  1793 W ActivityManager:   Force finishing activity com.namelessdev.mpdroid/.MainMenuActivity
```
