### PR TITLE
Add host attribute to fix 31d2ddf for pathPattern.

### DIFF
--- a/MPDroid/AndroidManifest.xml
+++ b/MPDroid/AndroidManifest.xml
@@ -176,6 +176,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
 
+		<data android:host="*" />
                 <data android:scheme="file" />
                 <data android:scheme="http" />
                 <data android:scheme="https" />


### PR DESCRIPTION
According to the Android Documentation, if a host is not specified for the
filter, the port attribute and all the path attributes are ignored.
