### PR TITLE
Extra newline after command list causes MPD 'No command given' error

### DIFF
--- a/JMPDComm/src/org/a0z/mpd/MPDConnection.java
+++ b/JMPDComm/src/org/a0z/mpd/MPDConnection.java
@@ -245,7 +245,7 @@ public abstract class MPDConnection {
         for (MPDCommand command : commandQueue) {
             commandstr += command.toString();
         }
-        commandstr += MPD_CMD_END_BULK + "\n";
+        commandstr += MPD_CMD_END_BULK;
         commandQueue = new ArrayList<MPDCommand>();
         return sendRawCommand(new MPDCommand(commandstr));
     }


### PR DESCRIPTION
There is an extra newline character appended to each command list request. This sends an erroneous empty MPD request after the command list but the "ACK [5@0] {} No command given" response is not read back from the server.

This becomes a noticeable problem when you do back-to-back command list requests. After n requests (where n is the number of command connection threads) the next request reuses a thread that's got an error response already waiting, so it will return this error rather than the expected response.  

The command list request seems to be re-issued and does eventually work, albeit slower than necessary. Except in the case of mopidy where it incorrectly returns "OK" for an empty command (a bug) so MPDroid doesn't re-request and the response is lost.
