### PR TITLE
Volume bar remove when MPD get volume returns -1 (no volume control)

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
@@ -188,9 +188,17 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
                             progressBarVolume.setProgress(volume);
                             if (volume == -1)
                             {
-                                    progressBarVolume.setEnabled(false);
-                                    progressBarVolume.setVisibility(View.GONE);
-                                    volumeIcon.setVisibility(View.GONE);
+                            	// volume is -1 when output device does not support
+                            	// a volume control, e.g. Optical Output
+                                progressBarVolume.setEnabled(false);
+                                progressBarVolume.setVisibility(View.GONE);
+                                volumeIcon.setVisibility(View.GONE);
+                            }
+                            else
+                            {
+                                progressBarVolume.setEnabled(false);
+                                progressBarVolume.setVisibility(View.VISIBLE);
+                                volumeIcon.setVisibility(View.VISIBLE);
                             }
                         }
                     });
@@ -239,9 +247,15 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
             final int volume = app.oMPDAsyncHelper.oMPD.getStatus().getVolume();
             if (volume == -1)
             {
-                    progressBarVolume.setEnabled(false);
-                    progressBarVolume.setVisibility(View.GONE);
-                    volumeIcon.setVisibility(View.GONE);
+                progressBarVolume.setEnabled(false);
+                progressBarVolume.setVisibility(View.GONE);
+                volumeIcon.setVisibility(View.GONE);
+            }
+            else
+            {
+                progressBarVolume.setEnabled(false);
+                progressBarVolume.setVisibility(View.VISIBLE);
+                volumeIcon.setVisibility(View.VISIBLE);
             }
                     
         } catch (MPDServerException e) {


### PR DESCRIPTION
Hi

He's a small submit to remove the volume bar when MPD server returns -1 on call to get volume. This indicates that the output device does not have a volume control, for instance optical output. The volume bar in this instances is useless to the user and performs not function and is slightly confusing to the user. Therefore we can detect this condition from the getVolume() and hide and disable the UI volume control.

Note: I've not tested with a MPD server that the output does support control of volume on the output device.

Phil 

some of the white space got changed in the process, I'm not sure how or why, but have corrected most that I can see
