### PR TITLE
Add copyright headers to most project java files.

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/AboutActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/AboutActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/ConnectionSettings.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/ConnectionSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/MPDApplication.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/MPDApplication.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/MPDroidActivities.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/MPDroidActivities.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/MainMenuActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/MainMenuActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/PhoneStateReceiver.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/PhoneStateReceiver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/RemoteControlReceiver.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/RemoteControlReceiver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/SearchActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/SearchActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 
@@ -77,6 +92,7 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
             return arg0 == ((View) arg1);
         }
     }
+
     public static final int MAIN = 0;
 
     public static final int PLAYLIST = 3;

--- a/MPDroid/src/com/namelessdev/mpdroid/SearchRecentProvider.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/SearchRecentProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/ServerBonjourListActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/ServerBonjourListActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 
@@ -51,9 +66,9 @@ public class ServerBonjourListActivity extends ListActivity implements ServiceLi
 
         listAdapter = new SimpleAdapter(this, servers, android.R.layout.simple_list_item_1,
                 new String[] {
-                    SERVER_NAME
+                        SERVER_NAME
                 }, new int[] {
-                    android.R.id.text1
+                        android.R.id.text1
                 });
         getListView().setAdapter(listAdapter);
     }

--- a/MPDroid/src/com/namelessdev/mpdroid/ServerListActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/ServerListActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/SettingsActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/SettingsActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 
@@ -56,6 +71,7 @@ public class SettingsActivity extends PreferenceActivity implements
         }
 
     }
+
     class OutputPreferenceClickListener implements OnPreferenceClickListener {
         @Override
         public boolean onPreferenceClick(Preference pref) {
@@ -78,6 +94,7 @@ public class SettingsActivity extends PreferenceActivity implements
             return true;
         }
     }
+
     private static final int MAIN = 0;
 
     private static final int ADD = 1;

--- a/MPDroid/src/com/namelessdev/mpdroid/URIHandlerActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/URIHandlerActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/WarningActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/WarningActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/WifiConnectionSettings.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/WifiConnectionSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/ArrayAdapter.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/ArrayAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/ArrayDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/ArrayDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/ArrayIndexerAdapter.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/ArrayIndexerAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/PopupMenuAdapter.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/PopupMenuAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/PopupMenuItem.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/PopupMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/SeparatedListAdapter.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/SeparatedListAdapter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/adapters/SeparatedListDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/adapters/SeparatedListDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.adapters;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/AbstractWebCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/AbstractWebCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/CachedCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/CachedCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -105,7 +120,7 @@ public class CachedCover implements ICoverRetriever {
             final String url = getAbsolutePathForSong(albumInfo);
             if (new File(url).exists())
                 return new String[] {
-                    url
+                        url
                 };
         }
         return null;

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/CoverBitmapDrawable.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/CoverBitmapDrawable.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/DeezerCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/DeezerCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -33,7 +48,7 @@ public class DeezerCover extends AbstractWebCover {
                 if (coverUrl != null) {
                     coverUrl += "&size=big";
                     return new String[] {
-                        coverUrl
+                            coverUrl
                     };
                 }
             }

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/DiscogsCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/DiscogsCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/GracenoteCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/GracenoteCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -18,9 +33,11 @@ public class GracenoteCover extends AbstractWebCover {
     private String clientId;
     public static final String USER_ID = "GRACENOTE_USERID";
     public static final String CUSTOM_CLIENT_ID_KEY = "gracenoteClientId";
+
     public static boolean isClientIdAvailable(SharedPreferences sharedPreferences) {
         return !isEmpty(sharedPreferences.getString(CUSTOM_CLIENT_ID_KEY, null));
     }
+
     private String apiUrl;
     private SharedPreferences sharedPreferences;
     private String userId;
@@ -129,7 +146,7 @@ public class GracenoteCover extends AbstractWebCover {
             coverUrl = getCoverUrl(albumInfo.getArtist(), albumInfo.getAlbum());
             if (coverUrl != null) {
                 return new String[] {
-                    coverUrl
+                        coverUrl
                 };
             }
         } catch (Exception ex) {

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/ICoverRetriever.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/ICoverRetriever.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/ItunesCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/ItunesCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -30,7 +45,7 @@ public class ItunesCover extends AbstractWebCover {
                     // is 100x100
                     // Bigger versions also exists.
                     return new String[] {
-                        coverUrl.replace("100x100", "600x600")
+                            coverUrl.replace("100x100", "600x600")
                     };
                 }
             }

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/LastFMCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/LastFMCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -50,7 +65,7 @@ public class LastFMCover extends AbstractWebCover {
                         imageUrl = xpp.getText();
                         if (imageUrl != null && imageUrl.length() > 0) {
                             return new String[] {
-                                imageUrl
+                                    imageUrl
                             };
                         }
                     }

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/LocalCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/LocalCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -39,6 +54,7 @@ public class LocalCover implements ICoverRetriever {
             }
         }
     }
+
     static public String buildCoverUrl(String serverName, String musicPath, String path,
             String fileName) {
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/MusicBrainzCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/MusicBrainzCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/cover/SpotifyCover.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/cover/SpotifyCover.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.cover;
 
@@ -83,7 +98,7 @@ public class SpotifyCover extends AbstractWebCover {
                 if (!isEmpty(coverUrl)) {
                     coverUrl = coverUrl.replace("/cover/", "/640/");
                     return new String[] {
-                        coverUrl
+                            coverUrl
                     };
                 }
             }

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/BaseDao.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/BaseDao.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/ConnectionProfileDao.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/ConnectionProfileDao.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/DaoFactory.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/DaoFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/BaseDBHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/BaseDBHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao.sqlite;
 
@@ -160,7 +175,7 @@ public abstract class BaseDBHelper<T> implements BaseDao<T> {
 
     public T get(long id) {
         return get(idColumnName + " = ?", new String[] {
-            Long.toString(id)
+                Long.toString(id)
         });
     }
 
@@ -281,7 +296,7 @@ public abstract class BaseDBHelper<T> implements BaseDao<T> {
         builder.append(id);
 
         final Cursor cursor = getDatabase().query(getMainTableName(), new String[] {
-            idColumnName
+                idColumnName
         }, builder.toString(), null, null, null,
                 null);
 

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/ConnectionProfileDao.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/ConnectionProfileDao.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao.sqlite;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/DatabaseOpenHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/DatabaseOpenHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao.sqlite;
 
@@ -9,6 +24,7 @@ public class DatabaseOpenHelper extends SQLiteOpenHelper {
     private static DatabaseOpenHelper _instance;
     private static final String DB_NAME = "digmaat.db";
     private static final int DB_VERSION = 1;
+
     public static void destroyInstance() {
         if (_instance != null) {
             _instance.closeDB();

--- a/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/exceptions/BaseDBHelperException.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/dao/sqlite/exceptions/BaseDBHelperException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.dao.sqlite.exceptions;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/data/model/ConnectionProfile.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/data/model/ConnectionProfile.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.data.model;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/AlbumsGridFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/AlbumsGridFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/ArtistsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/ArtistsFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/BrowseFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/BrowseFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/FSFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/FSFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/GenresFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/GenresFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/LibraryFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/LibraryFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 
@@ -188,6 +203,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
         }
 
     }
+
     private class PosTimerTask extends TimerTask {
         Date date = new Date();
         long start = 0;
@@ -215,6 +231,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
             lastElapsedTime = ellapsed;
         }
     }
+
     public class updateTrackInfoAsync extends AsyncTask<MPDStatus, Void, Boolean> {
         Music actSong = null;
         MPDStatus status = null;
@@ -328,6 +345,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
             }
         }
     }
+
     public static final String PREFS_NAME = "mpdroid.properties";
     private static final boolean DEBUG = false;
     private static final int POPUP_ARTIST = 0;
@@ -461,6 +479,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
         // TODO Auto-generated method stub
 
     }
+
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
@@ -629,6 +648,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
                     int lastSentVol = -1;
 
                     SeekBar progress;
+
                     public void run() {
                         if (lastSentVol != progress.getProgress()) {
                             lastSentVol = progress.getProgress();
@@ -876,7 +896,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
     private void setRepeatButton(boolean on) {
         if (null != repeatButton && repeatCurrent != on) {
             int[] attrs = new int[] {
-                on ? R.attr.repeatEnabled : R.attr.repeatDisabled
+                    on ? R.attr.repeatEnabled : R.attr.repeatDisabled
             };
             final TypedArray ta = activity.obtainStyledAttributes(attrs);
             final Drawable drawableFromTheme = ta.getDrawable(0);
@@ -889,7 +909,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
     private void setShuffleButton(boolean on) {
         if (null != shuffleButton && shuffleCurrent != on) {
             int[] attrs = new int[] {
-                on ? R.attr.shuffleEnabled : R.attr.shuffleDisabled
+                    on ? R.attr.shuffleEnabled : R.attr.shuffleDisabled
             };
             final TypedArray ta = activity.obtainStyledAttributes(attrs);
             final Drawable drawableFromTheme = ta.getDrawable(0);

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingSmallFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingSmallFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 
@@ -126,6 +141,7 @@ public class NowPlayingSmallFragment extends Fragment implements StatusChangeLis
             }
         }
     }
+
     private MPDApplication app;
     private CoverAsyncHelper coverHelper;
     private TextView songTitle;

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/PlaylistFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/PlaylistFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/PlaylistsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/PlaylistsFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 
@@ -61,6 +76,7 @@ public class PlaylistsFragment extends BrowseFragment {
             }
         }
     }
+
     public static final int EDIT = 101;
 
     public static final int DELETE = 102;

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/SongsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/SongsFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/StoredPlaylistFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/StoredPlaylistFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/StreamsFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/StreamsFragment.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.fragments;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/AlbumCache.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/AlbumCache.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 
@@ -73,6 +88,7 @@ public class AlbumCache
         }
         return instance;
     }
+
     protected boolean enabled = true;
     protected String server;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/AlbumCoverDownloadListener.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/AlbumCoverDownloadListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CachedMPD.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CachedMPD.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverAsyncHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverAsyncHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverDownloadListener.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverDownloadListener.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverInfo.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverManager.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/CoverManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 
@@ -78,6 +93,7 @@ public class CoverManager {
         SPOTIFY,
         ITUNES;
     }
+
     private class CreateBitmapTask implements Runnable
 
     {
@@ -103,14 +119,14 @@ public class CoverManager {
                 }
                 if (maxSize == CoverInfo.MAX_SIZE) {
                     bitmaps = new Bitmap[] {
-                        BitmapFactory.decodeByteArray(coverInfo.getCoverBytes(), 0,
-                                coverInfo.getCoverBytes().length)
+                            BitmapFactory.decodeByteArray(coverInfo.getCoverBytes(), 0,
+                                    coverInfo.getCoverBytes().length)
                     };
                     coverInfo.setBitmap(bitmaps);
                 } else {
                     bitmaps = new Bitmap[] {
-                        Tools.decodeSampledBitmapFromBytes(coverInfo.getCoverBytes(), maxSize,
-                                maxSize, false)
+                            Tools.decodeSampledBitmapFromBytes(coverInfo.getCoverBytes(), maxSize,
+                                    maxSize, false)
                     };
                     coverInfo.setBitmap(bitmaps);
                 }
@@ -171,6 +187,7 @@ public class CoverManager {
         }
 
     }
+
     private class FetchCoverTask implements Runnable
 
     {
@@ -303,6 +320,7 @@ public class CoverManager {
         }
 
     }
+
     private class RequestProcessorTask implements Runnable {
 
         @Override
@@ -418,6 +436,7 @@ public class CoverManager {
 
         }
     }
+
     private static final String[] DISC_REFERENCES = {
             "disc", "cd", "disque"
     };
@@ -430,13 +449,16 @@ public class CoverManager {
     private static final String FOLDER_SUFFIX = "/covers/";
     public static final String WRONG_COVERS_FILE_NAME = "wrong-covers.bin";
     public static final String COVERS_FILE_NAME = "covers.bin";
+
     private static ThreadPoolExecutor getCoverFetchExecutor() {
         return new ThreadPoolExecutor(2, 2, 0, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<Runnable>());
     }
+
     public static String getCoverFileName(AlbumInfo albumInfo) {
         return albumInfo.getKey() + ".jpg";
     }
+
     public synchronized static CoverManager getInstance(MPDApplication app,
             SharedPreferences settings) {
         if (instance == null) {
@@ -444,6 +466,7 @@ public class CoverManager {
         }
         return instance;
     }
+
     private MPDApplication app = null;
     private SharedPreferences settings = null;
     private static CoverManager instance = null;
@@ -812,7 +835,7 @@ public class CoverManager {
                                     coverInfo.getBitmap()[0].getConfig(),
                                     coverInfo.getBitmap()[0].isMutable() ? true : false);
                             coverInfo.setBitmap(new Bitmap[] {
-                                copyBitmap
+                                    copyBitmap
                             });
                         }
                         break;

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/MPDAsyncHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/MPDAsyncHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 
@@ -34,12 +49,14 @@ public class MPDAsyncHelper extends Handler {
     public interface AsyncExecListener {
         public void asyncExecSucceeded(int jobID);
     }
+
     // PMix internal ConnectionListener interface
     public interface ConnectionListener {
         public void connectionFailed(String message);
 
         public void connectionSucceeded(String message);
     }
+
     /**
      * Asynchronous worker thread-class for long during operations on JMPDComm
      */
@@ -159,6 +176,7 @@ public class MPDAsyncHelper extends Handler {
                     Tools.toObjectArray(mpdStatus, oldVolume)).sendToTarget();
         }
     }
+
     public class MPDConnectionInfo {
         public String sServer;
         public int iPort;
@@ -171,6 +189,7 @@ public class MPDAsyncHelper extends Handler {
             return conInfo.sServerStreaming == null ? sServer : sServerStreaming;
         }
     }
+
     // Event-ID's for PMix internal events...
     private static final int EVENT_CONNECT = 0;
     private static final int EVENT_DISCONNECT = 1;

--- a/MPDroid/src/com/namelessdev/mpdroid/helpers/MPDConnectionHandler.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/helpers/MPDConnectionHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.helpers;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/library/ILibraryFragmentActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/library/ILibraryFragmentActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.library;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/library/ILibraryTabActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/library/ILibraryTabActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.library;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/library/LibraryTabsSettings.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/library/LibraryTabsSettings.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.library;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/library/PlaylistEditActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/library/PlaylistEditActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.library;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/library/SimpleLibraryActivity.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/library/SimpleLibraryActivity.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.library;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/models/AbstractPlaylistMusic.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/models/AbstractPlaylistMusic.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.models;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/models/PlaylistSong.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/models/PlaylistSong.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.models;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/models/PlaylistStream.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/models/PlaylistStream.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.models;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/LibraryTabsUtil.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/LibraryTabsUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.tools;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/NetworkHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/NetworkHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.tools;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/SettingsHelper.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/SettingsHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.tools;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/StreamFetcher.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/StreamFetcher.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.tools;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/StringUtils.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/StringUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.tools;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/tools/Tools.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/tools/Tools.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.tools;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/AlbumDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/AlbumDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/AlbumGridDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/AlbumGridDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/BaseDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/BaseDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/FixedRatioRelativeLayout.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/FixedRatioRelativeLayout.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/MainMenuViewPager.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/MainMenuViewPager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/SearchResultDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/SearchResultDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/SongDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/SongDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/StoredPlaylistDataBinder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/StoredPlaylistDataBinder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/holders/AbstractViewHolder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/holders/AbstractViewHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views.holders;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/holders/AlbumViewHolder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/holders/AlbumViewHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views.holders;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/holders/PlayQueueViewHolder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/holders/PlayQueueViewHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views.holders;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/holders/PlaylistViewHolder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/holders/PlaylistViewHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views.holders;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/views/holders/SongViewHolder.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/views/holders/SongViewHolder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.views.holders;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/widgets/SimpleWidgetProvider.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/widgets/SimpleWidgetProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.widgets;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/widgets/SimpleWidgetProviderWithStop.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/widgets/SimpleWidgetProviderWithStop.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.widgets;
 

--- a/MPDroid/src/com/namelessdev/mpdroid/widgets/WidgetHelperService.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/widgets/WidgetHelperService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Arnaud Barisain Monrose (The MPDroid Project)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.namelessdev.mpdroid.widgets;
 


### PR DESCRIPTION
Add a copyright header to most of the project java files, unless they were obviously owned by someone else. Probably legal then even, but not really important. Secondly, remove a couple of nested conditionals in PhoneStateReceiver.
