### PR TITLE
NowPlaying*Fragment: Revert the changes to NowPlaying* to fix NPE bug.

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingFragment.java
@@ -239,15 +239,12 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
 
         @Override
         protected Boolean doInBackground(MPDStatus... params) {
-            MPD mpd = app.oMPDAsyncHelper.oMPD;
             Boolean result = false;
 
-            if(!mpd.isConnected()) {
-                Log.d(MPDApplication.TAG,"Media server is not yet connected.");
-            } else if (params == null) {
+            if (params == null) {
                 try {
                     // A recursive call doesn't seem that bad here.
-                    result = doInBackground(mpd.getStatus(true));
+                    result = doInBackground(app.oMPDAsyncHelper.oMPD.getStatus(true));
                 } catch (MPDServerException e) {
                     Log.d(MPDApplication.TAG, "Failed to populate params in the background.", e);
                 }
@@ -256,7 +253,7 @@ public class NowPlayingFragment extends Fragment implements StatusChangeListener
                 if (state != null) {
                     int songPos = params[0].getSongPos();
                     if (songPos >= 0) {
-                        actSong = mpd.getPlaylist().getByIndex(songPos);
+                        actSong = app.oMPDAsyncHelper.oMPD.getPlaylist().getByIndex(songPos);
                         status = params[0];
                         result = true;
                     }

--- a/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingSmallFragment.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/fragments/NowPlayingSmallFragment.java
@@ -57,15 +57,12 @@ public class NowPlayingSmallFragment extends Fragment implements StatusChangeLis
 
         @Override
         protected Boolean doInBackground(MPDStatus... params) {
-            MPD mpd = app.oMPDAsyncHelper.oMPD;
             Boolean result = false;
 
-            if(!mpd.isConnected()) {
-                Log.d(MPDApplication.TAG,"Media server is not yet connected.");
-            } else if (params == null) {
+            if (params == null) {
                 try {
                     // A recursive call doesn't seem that bad here.
-                    result = doInBackground(mpd.getStatus());
+                    result = doInBackground(app.oMPDAsyncHelper.oMPD.getStatus());
                 } catch (MPDServerException e) {
                     Log.d(MPDApplication.TAG, "Failed to populate params in the background.", e);
                 }
@@ -74,7 +71,7 @@ public class NowPlayingSmallFragment extends Fragment implements StatusChangeLis
                 if (state != null) {
                     int songPos = params[0].getSongPos();
                     if (songPos >= 0) {
-                        actSong = mpd.getPlaylist().getByIndex(songPos);
+                        actSong = app.oMPDAsyncHelper.oMPD.getPlaylist().getByIndex(songPos);
                         status = params[0];
                         result = true;
                     }


### PR DESCRIPTION
Apologies, I need to revert this change, and I'll write a bug on the NPE soon. It was a bad assumption that MPDroid would have no problem connecting after a false return; I know it has something to do with being async, but this stuff is (obviously) beyond me. I should have seen the bug initially, but it doesn't always reproduce.
