### PR TITLE
Use title, if present, for playlist mainline

### DIFF
--- a/MPDroid/src/com/namelessdev/mpdroid/models/PlaylistStream.java
+++ b/MPDroid/src/com/namelessdev/mpdroid/models/PlaylistStream.java
@@ -29,7 +29,12 @@ public class PlaylistStream extends AbstractPlaylistMusic {
     }
 
     public String getPlayListMainLine() {
-        return getName().replace("." + getExtension(getName()), "");
+        // If title is given in a stream's metadata it is likely more relevant than the filename
+	if (haveTitle()) {
+            return getTitle();
+       } else {
+            return getName().replace("." + getExtension(getName()), "");
+	}
     }
 
     public String getPlaylistSubLine() {


### PR DESCRIPTION
This is my first ever pull-request on GitHub, so I start simple :-)

For streams it is common for the filename to be something generated and
non-descriptive. If metadata for title exists, it is likely to be more
accurate. For streams specified in .pls playlists, this will use the
Title line.
This is also how the MPD web client in Volumio (Raspberry Pi) works.
