### PR TITLE
Better Search behaviour when using mopidy

### DIFF
--- a/JMPDComm/src/main/java/com/anpmech/mpd/MPD.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/MPD.java
@@ -696,7 +696,7 @@ public class MPD {
      */
     public Collection<Music> find(final String type, final String locatorString)
             throws IOException, MPDException {
-        return genericSearch(MPDCommand.MPD_CMD_FIND, type, locatorString);
+        return genericSearch(MPDCommand.MPD_CMD_FIND, type, locatorString,true);
     }
 
     public List<Music> find(final String[] args) throws IOException, MPDException {
@@ -756,10 +756,10 @@ public class MPD {
     }
 
     protected List<Music> genericSearch(final String searchCommand, final String type,
-            final String strToFind) throws IOException, MPDException {
+            final String strToFind, final boolean sort) throws IOException, MPDException {
         final List<String> response = mConnection.send(searchCommand, type, strToFind);
 
-        return MusicBuilder.buildMusicFromList(response, true);
+        return MusicBuilder.buildMusicFromList(response, sort);
     }
 
     public int getAlbumCount(final Artist artist, final boolean useAlbumArtistTag)
@@ -1666,14 +1666,15 @@ public class MPD {
      *                      MPD_SEARCH_FILENAME
      * @param locatorString case-insensitive locator locatorString. Anything that contains {@code
      *                      locatorString} will be returned in the results.
+     * @param sort          Sort search results alphabetically
      * @return a Collection of {@code Music}.
      * @throws IOException  Thrown upon a communication error with the server.
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      * @see com.anpmech.mpd.item.Music
      */
-    public List<Music> search(final String type, final String locatorString)
+    public List<Music> search(final String type, final String locatorString, boolean sort)
             throws IOException, MPDException {
-        return genericSearch(MPDCommand.MPD_CMD_SEARCH, type, locatorString);
+        return genericSearch(MPDCommand.MPD_CMD_SEARCH, type, locatorString,sort);
     }
 
     public List<Music> search(final String[] args) throws IOException, MPDException {

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/SearchActivity.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/SearchActivity.java
@@ -209,7 +209,9 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
         String tmpValue;
         boolean valueFound;
         for (final Music music : arrayMusic) {
-            if (music.getTitle() != null && music.getTitle().toLowerCase().contains(finalSearch)) {
+            if (music.getTitle() != null && music.getTitle().toLowerCase().contains(finalSearch)
+                    && !music.getFullPath().startsWith("spotify:artist:")
+                    && !music.getFullPath().startsWith("spotify:album:")) {
                 mSongResults.add(music);
             }
             valueFound = false;

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/SearchActivity.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/SearchActivity.java
@@ -31,8 +31,10 @@ import com.namelessdev.mpdroid.views.SearchResultDataBinder;
 
 import android.app.SearchManager;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Parcelable;
+import android.preference.PreferenceManager;
 import android.provider.SearchRecentSuggestions;
 import android.support.annotation.StringRes;
 import android.support.v4.app.FragmentTransaction;
@@ -190,7 +192,7 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
         List<Music> arrayMusic = null;
 
         try {
-            arrayMusic = mApp.oMPDAsyncHelper.oMPD.search("any", finalSearch);
+            arrayMusic = mApp.oMPDAsyncHelper.oMPD.search("any", finalSearch,false);
         } catch (final IOException | MPDException e) {
             Log.e(TAG, "MPD search failure.", e);
 
@@ -255,9 +257,13 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
             }
         }
 
-        Collections.sort(mArtistResults);
-        Collections.sort(mAlbumResults);
-        Collections.sort(mSongResults, Music.COMPARE_WITHOUT_TRACK_NUMBER);
+        final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this);
+
+        if (settings.getBoolean("sortSearchResults", true)) {
+            Collections.sort(mArtistResults);
+            Collections.sort(mAlbumResults);
+            Collections.sort(mSongResults, Music.COMPARE_WITHOUT_TRACK_NUMBER);
+        }
 
         runOnUiThread(new Runnable() {
             @Override

--- a/MPDroid/src/main/res/values/strings.xml
+++ b/MPDroid/src/main/res/values/strings.xml
@@ -164,6 +164,8 @@
     <string name="sortAlbumsByYearDescription">Sort albums by year</string>
     <string name="showAlbumTrackCount">Album track count</string>
     <string name="showAlbumTrackCountDescription">Show number of tracks on album</string>
+    <string name="sortSearchResults">Sort search results</string>
+    <string name="sortSearchResultsDescription">Sort search results alphabetically</string>
     <string name="enableLocalCover">Download local cover art</string>
     <string name="enableLocalCoverDescription">Get cover art from the server running MPD (requires a web server, read the wiki!)</string>
     <string name="musicPath">Path to music</string>

--- a/MPDroid/src/main/res/xml/settings.xml
+++ b/MPDroid/src/main/res/xml/settings.xml
@@ -180,6 +180,13 @@
             android:persistent="true"
             android:summary="@string/showAlbumTrackCountDescription"
             android:title="@string/showAlbumTrackCount" />
+
+	<CheckBoxPreference
+	    android:defaultValue="true"
+	    android:key="sortSearchResults"
+	    android:persistent="true"
+	    android:summary="@string/sortSearchResultsDescription"
+	    android:title="@string/sortSearchResults" /> 
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Hi there,

I am using MPDroid together with Mopidy. I changed two rather small things with the way mopidy and MPDroid interact when searching that in my opinion greatly improve user experience:
 - Mopidy includes Albums and Artists as explicit items in search results. Therefore album and artist results are listed in song results as well (prefaced by "Album: " and "Artist:". They are now filtered out by checking the beginning of the filename: If it begins with "spotify:album" or "spotify:artist", it is not included in the track list. (One could make this configurable, but i cannot think of any use case where you would want to display them)
 - When searching, there are just so many search results that ordering them alphabetically makes the relevant results disappear in all the noise. Fortunately, they already come ordered by relevancy. Therefore I added an option to disable sorting of search results.

Cheers,
Jakob