### PR TITLE
Toggle Comment Display in the Album View

### DIFF
--- a/JMPDComm/src/main/java/com/anpmech/mpd/item/AbstractMusic.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/item/AbstractMusic.java
@@ -114,6 +114,11 @@ abstract class AbstractMusic<T extends Music> extends Item<Music> implements Fil
     public static final String RESPONSE_TRACK = "Track";
 
     /**
+     * The media server response key returned for a Comment value.
+     */
+    public static final String RESPONSE_COMMENT = "Comment";
+
+    /**
      * The string used to refer to an album tag.
      */
     public static final String TAG_ALBUM = "album";
@@ -755,6 +760,17 @@ abstract class AbstractMusic<T extends Music> extends Item<Music> implements Fil
         }
 
         return streamName;
+    }
+
+    /**
+     * Retrieves the comment
+     *
+     * @return  The comments or an empty string
+     */
+    public String getComments() {
+        String comments = findValue(RESPONSE_COMMENT);
+        comments = comments == null ? "" : comments;
+        return comments;
     }
 
     /**

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/SongsFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/SongsFragment.java
@@ -114,6 +114,11 @@ public class SongsFragment extends BrowseFragment<Music> {
 
     private PopupMenu mCoverPopupMenu;
 
+    // Display song details (comments ...)
+    private boolean detailsDisplayed = false;
+
+    private  SongDataBinder<Music> musicSongDataBinder;
+
     public SongsFragment() {
         super(R.string.addSong, R.string.songAdded);
         mHandler = new Handler();
@@ -217,7 +222,8 @@ public class SongsFragment extends BrowseFragment<Music> {
                 break;
             }
         }
-        return new ArrayAdapter<>(getActivity(), new SongDataBinder<Music>(differentArtists),
+        musicSongDataBinder = new SongDataBinder<>(differentArtists);
+        return new ArrayAdapter<>(getActivity(), musicSongDataBinder,
                 mItems);
     }
 
@@ -362,6 +368,15 @@ public class SongsFragment extends BrowseFragment<Music> {
             populateViews(headerView);
             mCoverArt = (ImageView) headerView.findViewById(R.id.albumCover);
         }
+        // Toggle the song detail display
+        headerView.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                detailsDisplayed = !detailsDisplayed;
+                musicSongDataBinder.setDisplayDetails(detailsDisplayed);
+                mList.invalidateViews();
+            }
+        });
 
         ViewCompat.setTransitionName(mCoverArt, mViewTransitionName);
         if (mCoverThumbnailBitmap != null) {
@@ -621,7 +636,12 @@ public class SongsFragment extends BrowseFragment<Music> {
             if (mHeaderAlbum != null) {
                 mHeaderAlbum.setText(fixedAlbumInfo.getAlbumName());
             }
-            mHeaderInfo.setText(getHeaderInfoString());
+            // Display album year in header
+            String headerInfos = (String) getHeaderInfoString();
+            if (mAlbum != null && mAlbum.getDate() > 0) {
+                headerInfos = mAlbum.getDate() + ", " + headerInfos;
+            }
+            mHeaderInfo.setText(headerInfos);
             if (mCoverHelper != null) {
                 // Delay the cover art download for Lollipop transition
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && mFirstRefresh) {

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/views/SongDataBinder.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/views/SongDataBinder.java
@@ -33,6 +33,8 @@ public class SongDataBinder<T extends Item<T>> implements ArrayDataBinder<T> {
 
     private final boolean mShowArtist;
 
+    private boolean displayDetails = false;
+
     public SongDataBinder() {
         this(true);
     }
@@ -40,6 +42,10 @@ public class SongDataBinder<T extends Item<T>> implements ArrayDataBinder<T> {
     public SongDataBinder(final boolean showArtist) {
         super();
         mShowArtist = showArtist;
+    }
+
+    public void setDisplayDetails(boolean displayDetails) {
+        this.displayDetails = displayDetails;
     }
 
     @Override
@@ -79,7 +85,12 @@ public class SongDataBinder<T extends Item<T>> implements ArrayDataBinder<T> {
         holder.getTrackTitle().setText(song.getTitle());
         holder.getTrackNumber().setText(track);
         holder.getTrackDuration().setText(song.getFormattedTime());
-
+        if (displayDetails && song.getComments().length() > 0) {
+            holder.getTrackComments().setText(song.getComments());
+            holder.getTrackComments().setVisibility(View.VISIBLE);
+        } else {
+            holder.getTrackComments().setVisibility(View.GONE);
+        }
         if (mShowArtist) {
             holder.getTrackArtist().setText(song.getArtistName());
         }

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/views/holders/SongViewHolder.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/views/holders/SongViewHolder.java
@@ -48,6 +48,12 @@ public class SongViewHolder extends AbstractViewHolder {
     private final TextView mTrackTitle;
 
     /**
+     * The track comment View.
+     */
+    private final TextView mTrackComments;
+
+
+    /**
      * Sole constructor.
      *
      * @param view The current {@link View}.
@@ -59,6 +65,7 @@ public class SongViewHolder extends AbstractViewHolder {
         mTrackDuration = (TextView) view.findViewById(R.id.track_duration);
         mTrackNumber = (TextView) view.findViewById(R.id.track_number);
         mTrackTitle = (TextView) view.findViewById(R.id.track_title);
+        mTrackComments = (TextView) view.findViewById(R.id.track_comments);
     }
 
     /**
@@ -96,4 +103,14 @@ public class SongViewHolder extends AbstractViewHolder {
     public TextView getTrackTitle() {
         return mTrackTitle;
     }
+
+    /**
+     * Get the track comment View.
+     *
+     * @return The track comment View.
+     */
+    public TextView getTrackComments() {
+        return mTrackComments;
+    }
+
 }

--- a/MPDroid/src/main/res/layout-land/song_header.xml
+++ b/MPDroid/src/main/res/layout-land/song_header.xml
@@ -91,7 +91,7 @@
             android:singleLine="true"
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:textSize="12sp"
-            tools:text="Artist" />
+            tools:text="Tracks" />
     </RelativeLayout>
 
     <android.support.design.widget.FloatingActionButton

--- a/MPDroid/src/main/res/layout/song_header.xml
+++ b/MPDroid/src/main/res/layout/song_header.xml
@@ -97,7 +97,7 @@
             android:singleLine="true"
             android:textAppearance="?android:attr/textAppearanceSmall"
             android:textSize="12sp"
-            tools:text="Artist" />
+            tools:text="Tracks" />
     </RelativeLayout>
 
     <android.support.design.widget.FloatingActionButton

--- a/MPDroid/src/main/res/layout/song_list_item.xml
+++ b/MPDroid/src/main/res/layout/song_list_item.xml
@@ -14,28 +14,29 @@
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/material_list_item_height_big"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
     android:background="?attr/cardBackground"
     android:orientation="horizontal">
 
     <TextView
         android:id="@+id/track_number"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:gravity="center_vertical"
         android:paddingLeft="@dimen/material_list_item_element_horizontal_padding"
+        android:paddingTop="@dimen/material_list_item_element_vertical_padding"
         tools:text="01" />
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_toLeftOf="@+id/track_duration"
         android:layout_toRightOf="@+id/track_number"
         android:orientation="vertical"
-        android:paddingBottom="8dip"
+        android:paddingBottom="@dimen/material_list_item_element_vertical_padding"
         android:paddingLeft="@dimen/material_list_item_element_horizontal_padding"
-        android:paddingTop="8dip">
+        android:paddingTop="@dimen/material_list_item_element_vertical_padding">
 
         <TextView
             android:id="@+id/track_title"
@@ -59,15 +60,31 @@
             android:textAppearance="@style/TextAppearance.AppCompat.Body2"
             android:textColor="?attr/listItemSecondaryTextColor"
             tools:text="Artist" />
+        <TextView
+            android:id="@+id/track_comments"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="none"
+            android:gravity="center_vertical"
+            android:singleLine="false"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+            android:textColor="?attr/listItemSecondaryTextColor"
+            android:visibility="gone"
+
+            tools:text="Comments" />
+
     </LinearLayout>
 
     <TextView
         android:id="@+id/track_duration"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:gravity="center_vertical"
         android:paddingLeft="@dimen/material_list_item_element_horizontal_padding"
         android:paddingRight="@dimen/material_list_item_element_horizontal_padding"
+        android:paddingTop="@dimen/material_list_item_element_vertical_padding"
+
         tools:text="4:54" />
 </RelativeLayout>

--- a/MPDroid/src/main/res/values/dimens.xml
+++ b/MPDroid/src/main/res/values/dimens.xml
@@ -29,5 +29,7 @@
 
     <dimen name="material_list_item_height_big">68dip</dimen>
     <dimen name="material_list_item_element_horizontal_padding">16dip</dimen>
+    <dimen name="material_list_item_element_vertical_padding">8dip</dimen>
+
 
 </resources>


### PR DESCRIPTION
Hi,
There is a lot of time I did not contribute to this great project ...
A lot of great things have been done. I keep on using MPDroid everyday and I really enjoy it. Thanks !

A feature I miss is a way to display song comments.
For me it is very useful with podcasts that contain a quick overview of the episode as comments.

Of course you need to setup your mpd server to read the comment tags.

I tried to add this feature without changing any existing behaviour :

In the album view :
- Tap the album header to toggle song comment display (an other tap restores the original display)
- Add the album year in the header

Some pictures to show the result.
- Before a tap on the album header:
![mpdroid-album-without-comments](https://cloud.githubusercontent.com/assets/1272343/9704219/37e05bee-549e-11e5-9eae-fa7e988cf6d1.png)

-After a tap on the album header:
![mpdroid-album-with-comments](https://cloud.githubusercontent.com/assets/1272343/9704226/5e14bc56-549e-11e5-9b69-5b0300f2eabf.png)

Thanks again for the great work !



