### PR TITLE
Remove artist under cover from artist library view

### DIFF
--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
@@ -159,7 +159,7 @@ public class AlbumsFragment extends BrowseFragment<Album> {
 
     @Override
     protected ListAdapter getCustomListAdapter() {
-        return new ArrayIndexerAdapter<>(getActivity(), new AlbumDataBinder<Album>(), mItems);
+        return new ArrayIndexerAdapter<>(getActivity(), new AlbumDataBinder<Album>(mArtist==null), mItems);
     }
 
     /**

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/AlbumsGridFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/AlbumsGridFragment.java
@@ -35,7 +35,7 @@ public class AlbumsGridFragment extends AlbumsFragment {
 
     @Override
     protected ListAdapter getCustomListAdapter() {
-        return new ArrayAdapter<>(getActivity(), new AlbumGridDataBinder(), mItems);
+        return new ArrayAdapter<>(getActivity(), new AlbumGridDataBinder(mArtist==null), mItems);
     }
 
     @Override

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/views/AlbumDataBinder.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/views/AlbumDataBinder.java
@@ -44,13 +44,16 @@ public class AlbumDataBinder<T extends Item<T>> extends BaseDataBinder<T> {
 
     private final boolean mUseYear;
 
-    public AlbumDataBinder() {
+    private boolean displayArtist;
+
+    public AlbumDataBinder(boolean displayArtist) {
         super();
 
         final MPDApplication app = MPDApplication.getInstance();
         final SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(app);
 
         mUseYear = settings.getBoolean("enableAlbumYearText", true);
+        this.displayArtist = displayArtist;
     }
 
     @Override
@@ -106,33 +109,35 @@ public class AlbumDataBinder<T extends Item<T>> extends BaseDataBinder<T> {
         final StringBuilder info = new StringBuilder();
         final long songCount = album.getSongCount();
 
-        if (artist != null) {
+        if (displayArtist && artist != null) {
             info.append(artist.toString());
         }
-
-        if (mUseYear && album.getDate() > 0L) {
-            if (info.length() != 0) {
-                info.append(SEPARATOR);
-            }
-            info.append(Long.toString(album.getDate()));
-        }
-
-        if (songCount > 0L) {
-            final String trackHeader;
-            final CharSequence duration = Tools.timeToString(album.getDuration());
-
-            if (info.length() != 0) {
-                info.append(SEPARATOR);
+        // If the artist is displayed do not display extra informations since they do not fit on screen
+        else {
+            if (mUseYear && album.getDate() > 0L) {
+                if (info.length() != 0) {
+                    info.append(SEPARATOR);
+                }
+                info.append(Long.toString(album.getDate()));
             }
 
-            if (songCount > 1L) {
-                trackHeader =
-                        context.getString(R.string.tracksInfoHeaderPlural, songCount, duration);
-            } else {
-                trackHeader = context.getString(R.string.tracksInfoHeader, songCount, duration);
-            }
+            if (songCount > 0L) {
+                final String trackHeader;
+                final CharSequence duration = Tools.timeToString(album.getDuration());
 
-            info.append(trackHeader);
+                if (info.length() != 0) {
+                    info.append(SEPARATOR);
+                }
+
+                if (songCount > 1L) {
+                    trackHeader =
+                            context.getString(R.string.tracksInfoHeaderPlural, songCount, duration);
+                } else {
+                    trackHeader = context.getString(R.string.tracksInfoHeader, songCount, duration);
+                }
+
+                info.append(trackHeader);
+            }
         }
 
         // display "artist - album title"

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/views/AlbumGridDataBinder.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/views/AlbumGridDataBinder.java
@@ -26,6 +26,10 @@ import android.support.annotation.LayoutRes;
 
 public class AlbumGridDataBinder extends AlbumDataBinder<Album> {
 
+    public AlbumGridDataBinder(final boolean displayArtist) {
+        super(displayArtist);
+    }
+
     @Override
     @LayoutRes
     public int getLayoutId() {


### PR DESCRIPTION
To fix #715 

It remains an issue (at least when the album cache is enabled) : the displayed album track number is not correct. It always displays 1.
The problem already exists in the develop branch.

I think it is related to the album cache. The listAllInfo method in MPD.java returns a wrong number of "Music". So the built cache is wrong.
It is just a guess since I do not know the code that well anymore.

@avuton, @abarisain : Do you know this problem ?

