### PR TITLE
searching for tracks considers the search pattern in filenames too

### DIFF
--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/SearchActivity.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/SearchActivity.java
@@ -188,16 +188,25 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
         final String finalSearch = mSearchKeywords.toLowerCase();
 
         List<Music> arrayMusic = null;
+        List<Music> arrayMusicFiles = null;
 
         try {
             arrayMusic = mApp.oMPDAsyncHelper.oMPD.search("any", finalSearch);
         } catch (final IOException | MPDException e) {
             Log.e(TAG, "MPD search failure.", e);
-
         }
 
         if (arrayMusic == null) {
             return;
+        }
+
+        try {
+            arrayMusicFiles = mApp.oMPDAsyncHelper.oMPD.search("filename", finalSearch);
+        } catch (final IOException | MPDException e) {
+            Log.e(TAG, "MPD search failure.", e);
+        }
+        if (arrayMusicFiles == null) {
+            arrayMusicFiles = new ArrayList();
         }
 
         mArtistResults.clear();
@@ -207,6 +216,15 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
         String tmpValue;
         boolean valueFound;
         for (final Music music : arrayMusic) {
+            for (final Music fMusic : arrayMusicFiles) {
+                final String fMusicFullPath = fMusic.getFullPath();
+                if (fMusicFullPath != null &&
+                        fMusicFullPath.equals(music.getFullPath())) {
+                    arrayMusicFiles.remove(fMusic);
+                    break;
+                }
+            }
+
             if (music.getTitle() != null && music.getTitle().toLowerCase().contains(finalSearch)) {
                 mSongResults.add(music);
             }
@@ -253,6 +271,10 @@ public class SearchActivity extends MPDroidActivity implements OnMenuItemClickLi
                     }
                 }
             }
+        }
+
+        for (final Music music : arrayMusicFiles) {
+            mSongResults.add(music);
         }
 
         Collections.sort(mArtistResults);


### PR DESCRIPTION
Searching for tracks currently uses the MPD search command with type "any". The type "any" only considers tags like id3 or something. The type "filename" is a special type not included by "any". This pull request allows MPDroid to find files with the matching search pattern in filenames too.