### PR TITLE
library browse: add tab 'random album'

### DIFF
--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/BrowseFragmentBase.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/BrowseFragmentBase.java
@@ -96,9 +96,9 @@ abstract class BrowseFragmentBase<T extends Item<T>> extends Fragment implements
 
     public static final int GOTO_ARTIST = 5;
 
-    public static final int MAIN = 0;
+//    public static final int MAIN = 0;
 
-    public static final int PLAYLIST = 3;
+//    public static final int PLAYLIST = 3;
 
     public static final int POPUP_COVER_BLACKLIST = 10;
 
@@ -136,9 +136,9 @@ abstract class BrowseFragmentBase<T extends Item<T>> extends Fragment implements
 
     protected final List<T> mItems = new ArrayList<>();
 
-    final int mIrAdd;
+    protected final int mIrAdd;
 
-    final int mIrAdded;
+    protected final int mIrAdded;
 
     /**
      * This runnable is run in our {@link MPDAsyncWorker} thread.

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/LibraryFragmentBase.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/LibraryFragmentBase.java
@@ -179,6 +179,9 @@ abstract class LibraryFragmentBase extends Fragment {
                 case LibraryTabsUtil.TAB_STREAMS:
                     fragment = getFragment(StreamsFragment.class);
                     break;
+                case LibraryTabsUtil.TAB_RANDOM:
+                    fragment = getFragment(RandomBrowseFragment.class);
+                    break;
                 default:
                     throw new IllegalStateException("getItem() called with invalid Item.");
             }

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/RandomBrowseFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/RandomBrowseFragment.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2010-2016 The MPDroid Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.namelessdev.mpdroid.fragments;
+
+
+import android.support.annotation.StringRes;
+import android.util.Log;
+
+import com.anpmech.mpd.exception.MPDException;
+import com.anpmech.mpd.item.Album;
+import com.namelessdev.mpdroid.R;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Random;
+
+public class RandomBrowseFragment extends SongsFragment {
+
+    private static final String TAG = "RandomBrowseFragment";
+
+    @Override
+    protected void asyncUpdate() {
+        try {
+            final List<Album> albums = mApp.getMPD().getAlbums(null, false, false);
+            mAlbum = !albums.isEmpty() ? albums.get(new Random().nextInt(albums.size())) : null;
+        } catch (final IOException | MPDException e) {
+            Log.e(TAG, "Failed to update.", e);
+        }
+
+        super.asyncUpdate();
+    }
+
+    @Override
+    public String getTitle() {
+        return mAlbum != null ? mAlbum.getName() : null;
+    }
+
+    @Override
+    @StringRes
+    public int getLoadingText() {
+        return R.string.loadingAlbum;
+    }
+
+}
+

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/SongsFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/SongsFragment.java
@@ -57,7 +57,6 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
-import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.ImageView;
 import android.widget.ListAdapter;
@@ -84,33 +83,33 @@ public class SongsFragment extends BrowseFragment<Music> implements
 
     private static final String TAG = "SongsFragment";
 
-    Album mAlbum;
+    protected Album mAlbum;
 
-    FloatingActionButton mAlbumMenu;
+    private FloatingActionButton mAlbumMenu;
 
-    ImageView mCoverArt;
+    private ImageView mCoverArt;
 
-    ProgressBar mCoverArtProgress;
+    private ProgressBar mCoverArtProgress;
 
-    CoverAsyncHelper mCoverHelper;
+    private CoverAsyncHelper mCoverHelper;
 
-    Bitmap mCoverThumbnailBitmap;
+    private Bitmap mCoverThumbnailBitmap;
 
-    boolean mFirstRefresh;
+    private boolean mFirstRefresh;
 
-    Handler mHandler;
+    private Handler mHandler;
 
-    TextView mHeaderAlbum;
+    private TextView mHeaderAlbum;
 
-    TextView mHeaderArtist;
+    private TextView mHeaderArtist;
 
-    TextView mHeaderInfo;
+    private TextView mHeaderInfo;
 
-    Toolbar mHeaderToolbar;
+    private Toolbar mHeaderToolbar;
 
-    View mTracksInfoContainer;
+    private View mTracksInfoContainer;
 
-    String mViewTransitionName;
+    private String mViewTransitionName;
 
     private AlbumCoverDownloadListener mCoverArtListener;
 
@@ -185,10 +184,10 @@ public class SongsFragment extends BrowseFragment<Music> implements
     }
 
     @Override
-    public void asyncUpdate() {
+    protected void asyncUpdate() {
         try {
             if (getActivity() != null) {
-                replaceItems(mApp.getMPD().getSongs(mAlbum));
+                replaceItems(mAlbum != null ? mApp.getMPD().getSongs(mAlbum) : Collections.<Music>emptyList());
                 Collections.sort(mItems);
             }
         } catch (final IOException | MPDException e) {
@@ -344,21 +343,19 @@ public class SongsFragment extends BrowseFragment<Music> implements
     }
 
     @Override
+    protected int getLayoutResId() {
+        return R.layout.songs;
+    }
+
+    @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup container,
             final Bundle savedInstanceState) {
-        final View view = inflater.inflate(R.layout.songs, container, false);
-        mList = (AbsListView) view.findViewById(R.id.list);
-        registerForContextMenu(mList);
-        mList.setOnItemClickListener(this);
+        final View view = super.onCreateView(inflater, container, savedInstanceState);
+
         mList.setFastScrollEnabled(false);
         if (mList instanceof ListView) {
             ((ListView) mList).setDivider(null);
         }
-
-        mLoadingView = view.findViewById(R.id.loadingLayout);
-        mLoadingTextView = (TextView) view.findViewById(R.id.loadingText);
-        mNoResultView = view.findViewById(R.id.noResultLayout);
-        mLoadingTextView.setText(getLoadingText());
 
         final View headerView = inflater.inflate(R.layout.song_header, mList, false);
         mCoverArt = (ImageView) view.findViewById(R.id.albumCover);

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/tools/LibraryTabsUtil.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/tools/LibraryTabsUtil.java
@@ -41,6 +41,8 @@ public final class LibraryTabsUtil {
 
     public static final String TAB_STREAMS = "streams";
 
+    public static final String TAB_RANDOM = "random";
+
     private static final MPDApplication APP = MPDApplication.getInstance();
 
     private static final String LIBRARY_TABS_DELIMITER = "|";
@@ -50,7 +52,8 @@ public final class LibraryTabsUtil {
             + LIBRARY_TABS_DELIMITER + TAB_PLAYLISTS
             + LIBRARY_TABS_DELIMITER + TAB_STREAMS
             + LIBRARY_TABS_DELIMITER + TAB_FILES
-            + LIBRARY_TABS_DELIMITER + TAB_GENRES;
+            + LIBRARY_TABS_DELIMITER + TAB_GENRES
+            + LIBRARY_TABS_DELIMITER + TAB_RANDOM;
 
     private static final String LIBRARY_TABS_SETTINGS_KEY = "currentLibraryTabs";
 
@@ -63,6 +66,7 @@ public final class LibraryTabsUtil {
         TABS.put(TAB_STREAMS, R.string.streams);
         TABS.put(TAB_FILES, R.string.files);
         TABS.put(TAB_GENRES, R.string.genres);
+        TABS.put(TAB_RANDOM, R.string.random);
     }
 
     private LibraryTabsUtil() {

--- a/MPDroid/src/main/res/values/strings.xml
+++ b/MPDroid/src/main/res/values/strings.xml
@@ -73,6 +73,7 @@
     <string name="playlists">Playlists</string>
     <string name="files">Files</string>
     <string name="albums">Albums</string>
+    <string name="random">Random</string>
     <string name="settings">Settings</string>
     <string name="next">Next</string>
     <string name="previous">Previous</string>
@@ -82,6 +83,7 @@
     <string name="loading">Loading…</string>
     <string name="loadingGenres">Loading genres…</string>
     <string name="loadingAlbums">Loading albums…</string>
+    <string name="loadingAlbum">Loading album…</string>
     <string name="loadingArtists">Loading artists…</string>
     <string name="loadingSongs">Loading songs…</string>
     <string name="loadingPlaylists">Loading playlists…</string>


### PR DESCRIPTION
Large music libraries have the problem, that albums get lost - you have forgotten that they even exists. And sometimes you don't know what to hear next. (at least my problems)
Therefore I have added a tab that randomly shows an album.