### PR TITLE
Feature: Genre optimization

### DIFF
--- a/JMPDComm/src/main/java/com/anpmech/mpd/AbstractResponseObject.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/AbstractResponseObject.java
@@ -164,7 +164,7 @@ public class AbstractResponseObject {
             isEqual = Boolean.TRUE;
         }
 
-        return isEqual.booleanValue();
+        return isEqual;
     }
 
     /**

--- a/JMPDComm/src/main/java/com/anpmech/mpd/MPDPlaylist.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/MPDPlaylist.java
@@ -159,7 +159,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void add(final FilesystemTreeEntry entry) throws IOException, MPDException {
-        mConnection.send(addCommand(entry.getFullPath()));
+        mConnection.submit(addCommand(entry.getFullPath()));
     }
 
     /**
@@ -171,7 +171,7 @@ public class MPDPlaylist {
      * @see Music
      */
     public void addAll(final Iterable<Music> collection) throws IOException, MPDException {
-        mConnection.send(addAllCommand(collection));
+        mConnection.submit(addAllCommand(collection));
     }
 
     /**
@@ -182,7 +182,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void addStream(final String url) throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_ADD, url);
+        mConnection.submit(MPD_CMD_PLAYLIST_ADD, url);
     }
 
     /**
@@ -192,7 +192,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void clear() throws IOException, MPDException {
-        mConnection.send(clearCommand());
+        mConnection.submit(clearCommand());
     }
 
     /**
@@ -273,7 +273,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void load(final String file) throws IOException, MPDException {
-        mConnection.send(loadCommand(file));
+        mConnection.submit(loadCommand(file));
     }
 
     /**
@@ -285,7 +285,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void move(final int songId, final int to) throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_MOVE_ID, Integer.toString(songId),
+        mConnection.submit(MPD_CMD_PLAYLIST_MOVE_ID, Integer.toString(songId),
                 Integer.toString(to));
     }
 
@@ -299,7 +299,7 @@ public class MPDPlaylist {
      * @see #move(int, int)
      */
     public void moveByPosition(final int from, final int to) throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_MOVE, Integer.toString(from),
+        mConnection.submit(MPD_CMD_PLAYLIST_MOVE, Integer.toString(from),
                 Integer.toString(to));
     }
 
@@ -320,7 +320,7 @@ public class MPDPlaylist {
             final String endRange = Integer.toString(start + number);
             final String target = Integer.toString(to);
             mConnection
-                    .send(MPD_CMD_PLAYLIST_MOVE, beginRange + ':' + endRange, target);
+                    .submit(MPD_CMD_PLAYLIST_MOVE, beginRange + ':' + endRange, target);
         }
     }
 
@@ -391,7 +391,7 @@ public class MPDPlaylist {
         for (final int id : songIds) {
             commandQueue.add(MPD_CMD_PLAYLIST_REMOVE_ID, Integer.toString(id));
         }
-        mConnection.send(commandQueue);
+        mConnection.submit(commandQueue);
     }
 
     /**
@@ -408,7 +408,7 @@ public class MPDPlaylist {
             commandQueue.add(MPD_CMD_PLAYLIST_REMOVE_ID, id.toString());
         }
 
-        mConnection.send(commandQueue);
+        mConnection.submit(commandQueue);
     }
 
     /**
@@ -429,7 +429,7 @@ public class MPDPlaylist {
                 commandQueue.add(MPD_CMD_PLAYLIST_REMOVE, Integer.toString(i));
             }
         }
-        mConnection.send(commandQueue);
+        mConnection.submit(commandQueue);
     }
 
     /**
@@ -451,7 +451,7 @@ public class MPDPlaylist {
             }
         }
 
-        mConnection.send(commandQueue);
+        mConnection.submit(commandQueue);
     }
 
     /**
@@ -462,7 +462,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void removePlaylist(final String file) throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_DELETE, file);
+        mConnection.submit(MPD_CMD_PLAYLIST_DELETE, file);
     }
 
     /**
@@ -479,7 +479,7 @@ public class MPDPlaylist {
         } catch (final MPDException ignored) {
             /** We're removing it just in case it exists. */
         }
-        mConnection.send(MPD_CMD_PLAYLIST_SAVE, file);
+        mConnection.submit(MPD_CMD_PLAYLIST_SAVE, file);
     }
 
     /**
@@ -489,7 +489,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void shuffle() throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_SHUFFLE);
+        mConnection.submit(MPD_CMD_PLAYLIST_SHUFFLE);
     }
 
     /**
@@ -511,7 +511,7 @@ public class MPDPlaylist {
      * @throws MPDException Thrown if an error occurs as a result of command execution.
      */
     public void swap(final int song1Id, final int song2Id) throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_SWAP_ID,
+        mConnection.submit(MPD_CMD_PLAYLIST_SWAP_ID,
                 Integer.toString(song1Id), Integer.toString(song2Id));
     }
 
@@ -525,7 +525,7 @@ public class MPDPlaylist {
      * @see #swap(int, int)
      */
     public void swapByPosition(final int song1, final int song2) throws IOException, MPDException {
-        mConnection.send(MPD_CMD_PLAYLIST_SWAP, Integer.toString(song1),
+        mConnection.submit(MPD_CMD_PLAYLIST_SWAP, Integer.toString(song1),
                 Integer.toString(song2));
     }
 

--- a/JMPDComm/src/main/java/com/anpmech/mpd/connection/MPDConnection.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/connection/MPDConnection.java
@@ -165,8 +165,6 @@ public abstract class MPDConnection implements MPDConnectionListener {
      * @see #connect(InetAddress, int)
      */
     MPDConnection(final int readWriteTimeout, final boolean blockingIO) {
-        super();
-
         mReadWriteTimeout = readWriteTimeout;
 
         if (blockingIO) {

--- a/JMPDComm/src/main/java/com/anpmech/mpd/item/AbstractItem.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/item/AbstractItem.java
@@ -30,6 +30,7 @@ package com.anpmech.mpd.item;
 
 import java.text.Collator;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -68,46 +69,23 @@ abstract class AbstractItem<T extends AbstractItem<T>> implements Comparable<T> 
     }
 
     /**
-     * This method merges two Item type lists.
-     *
-     * <p>This method removes unknown items and items not of the same name, then adds the remainder
-     * to {@code list1}.</p>
+     * This method merges two Item type lists into {@code list1} and removes unknown items and
+     * items of the same name.
      *
      * @param list1 The first list to merge, the list which will be merged into.
-     * @param list2 The second list to merge, do not reuse this list after calling this method.
+     * @param list2 The second list to merge.
      * @param <T>   Anything that extends an AbstractItem.
      */
     public static <T extends AbstractItem<T>> void merge(final List<T> list1, final List<T> list2) {
+        list1.addAll(list2);
         Collections.sort(list1);
-        Collections.sort(list2);
 
-        final ListIterator<T> iterator2 = list2.listIterator();
-        int position = 0;
-        ListIterator<T> iterator1 = list1.listIterator(position);
-
-        while (iterator2.hasNext()) {
-            final T item2 = iterator2.next();
-
-            if (position != iterator1.previousIndex()) {
-                iterator1 = list1.listIterator(position);
-            }
-            while (iterator1.hasNext()) {
-                final T item1 = iterator1.next();
-
-                if (item1.isUnknown()) {
-                    iterator1.remove();
-                    continue;
-                }
-
-                if (item1.isNameSame(item2)) {
-                    position = iterator1.previousIndex();
-                    iterator2.remove();
-                    break;
-                }
+        for (int i = list1.size()-1; i>= 0; i--) {
+            final T item = list1.get(i);
+            if (item.isUnknown() || i>0 && item.isNameSame(list1.get(i-1))) {
+                list1.remove(i);
             }
         }
-
-        list1.addAll(list2);
     }
 
     /**

--- a/JMPDComm/src/main/java/com/anpmech/mpd/item/AbstractResponseItem.java
+++ b/JMPDComm/src/main/java/com/anpmech/mpd/item/AbstractResponseItem.java
@@ -110,7 +110,7 @@ public abstract class AbstractResponseItem<T extends AbstractResponseItem<T>> ex
             isEqual = Boolean.TRUE;
         }
 
-        return isEqual.booleanValue();
+        return isEqual;
     }
 
     /**

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/AlbumsFragment.java
@@ -27,6 +27,7 @@ import com.namelessdev.mpdroid.cover.CoverAsyncHelper;
 import com.namelessdev.mpdroid.cover.CoverManager;
 import com.namelessdev.mpdroid.helpers.AlbumInfo;
 import com.namelessdev.mpdroid.library.ILibraryFragmentActivity;
+import com.namelessdev.mpdroid.models.GenresGroup;
 import com.namelessdev.mpdroid.tools.Tools;
 import com.namelessdev.mpdroid.views.AlbumDataBinder;
 import com.namelessdev.mpdroid.views.holders.AlbumViewHolder;
@@ -59,11 +60,11 @@ public class AlbumsFragment extends BrowseFragment<Album> {
 
     private static final String TAG = "AlbumsFragment";
 
-    protected Artist mArtist = null;
+    protected Artist mArtist;
 
     protected ProgressBar mCoverArtProgress;
 
-    protected Genre mGenre = null;
+    private GenresGroup mGenresGroups;
 
     protected boolean mIsCountDisplayed;
 
@@ -116,9 +117,9 @@ public class AlbumsFragment extends BrowseFragment<Album> {
                 Collections.sort(mItems);
             }
 
-            if (mGenre != null) { // filter albums not in genre
+            if (mGenresGroups != null) { // filter albums not in genre
                 for (int i = mItems.size() - 1; i >= 0; i--) {
-                    if (!mApp.getMPD().isAlbumInGenre(mItems.get(i), mGenre)) {
+                    if (!isAlbumInOneGenre(mItems.get(i), mGenresGroups)) {
                         mItems.remove(i);
                     }
                 }
@@ -126,6 +127,15 @@ public class AlbumsFragment extends BrowseFragment<Album> {
         } catch (final IOException | MPDException e) {
             Log.e(TAG, "Failed to update.", e);
         }
+    }
+
+    private boolean isAlbumInOneGenre(final Album album, final GenresGroup genres) throws IOException, MPDException {
+        for (final Genre genre : genres.getGenres()) {
+            if (mApp.getMPD().isAlbumInGenre(album, genre)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -206,7 +216,7 @@ public class AlbumsFragment extends BrowseFragment<Album> {
 
         if (bundle != null) {
             mArtist = bundle.getParcelable(Artist.EXTRA);
-            mGenre = bundle.getParcelable(Genre.EXTRA);
+            mGenresGroups = bundle.getParcelable(GenresGroup.EXTRA);
         }
     }
 
@@ -296,8 +306,8 @@ public class AlbumsFragment extends BrowseFragment<Album> {
             outState.putParcelable(Artist.EXTRA, mArtist);
         }
 
-        if (mGenre != null) {
-            outState.putParcelable(Genre.EXTRA, mGenre);
+        if (mGenresGroups != null) {
+            outState.putParcelable(GenresGroup.EXTRA, mGenresGroups);
         }
         super.onSaveInstanceState(outState);
     }

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/ArtistsFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/ArtistsFragment.java
@@ -96,35 +96,20 @@ public class ArtistsFragment extends BrowseFragment<Artist> {
             switch (settings.getString(PREFERENCE_ARTIST_TAG_TO_USE,
                     PREFERENCE_ARTIST_TAG_TO_USE_BOTH).toLowerCase()) {
                 case PREFERENCE_ARTIST_TAG_TO_USE_ALBUMARTIST:
-                    if (mGenresGroup == null) {
-                        artists = mApp.getMPD().getAlbumArtists();
-                    } else {
-                        artists = new HashSet<>();
-                        for (final Genre genre : mGenresGroup.getGenres()) {
-                            artists.addAll(mApp.getMPD().getAlbumArtists(genre));
-                        }
-                    }
+                    artists = mGenresGroup == null ?
+                            mApp.getMPD().getAlbumArtists() :
+                            mApp.getMPD().getAlbumArtists(mGenresGroup.getGenres());
                     break;
                 case PREFERENCE_ARTIST_TAG_TO_USE_ARTIST:
-                    if (mGenresGroup == null) {
-                        artists = mApp.getMPD().getArtists();
-                    } else {
-                        artists = new HashSet<>();
-                        for (final Genre genre : mGenresGroup.getGenres()) {
-                            artists.addAll(mApp.getMPD().getArtists(genre));
-                        }
-                    }
+                    artists = mGenresGroup == null ?
+                            mApp.getMPD().getArtists() :
+                            mApp.getMPD().getArtists(mGenresGroup.getGenres());
                     break;
                 case PREFERENCE_ARTIST_TAG_TO_USE_BOTH:
                 default:
-                    if (mGenresGroup == null) {
-                        artists = mApp.getMPD().getArtistsMerged();
-                    } else {
-                        artists = new HashSet<>();
-                        for (final Genre genre : mGenresGroup.getGenres()) {
-                            artists.addAll(mApp.getMPD().getArtistsMerged(genre));
-                        }
-                    }
+                    artists = mGenresGroup == null ?
+                            mApp.getMPD().getArtistsMerged() :
+                            mApp.getMPD().getArtistsMerged(mGenresGroup.getGenres());
                     break;
             }
             replaceItems(artists);

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/GenresFragment.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/fragments/GenresFragment.java
@@ -59,9 +59,7 @@ public class GenresFragment extends BrowseFragment<GenresGroup> {
     @Override
     protected void add(final GenresGroup item, final boolean replace, final boolean play) {
         try {
-            for (final Genre genre : item.getGenres()) {
-                mApp.getMPD().add(genre, replace, play);
-            }
+            mApp.getMPD().add(item.getGenres(), replace, play);
             Tools.notifyUser(mIrAdded, item);
         } catch (final IOException | MPDException e) {
             Log.e(TAG, "Failed to add all from playlist.", e);
@@ -71,9 +69,7 @@ public class GenresFragment extends BrowseFragment<GenresGroup> {
     @Override
     protected void add(final GenresGroup item, final PlaylistFile playlist) {
         try {
-            for (final Genre genre : item.getGenres()) {
-                mApp.getMPD().addToPlaylist(playlist, genre);
-            }
+            mApp.getMPD().addToPlaylist(playlist, item.getGenres());
             Tools.notifyUser(mIrAdded, item);
         } catch (final IOException | MPDException e) {
             Log.e(TAG, "Failed to add all genre to playlist.", e);

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/models/GenresGroup.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/models/GenresGroup.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2010-2016 The MPDroid Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.namelessdev.mpdroid.models;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import com.anpmech.mpd.ResponseObject;
+import com.anpmech.mpd.item.Genre;
+import com.anpmech.mpd.item.Item;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class GenresGroup extends Item<GenresGroup> {
+
+    /**
+     * This field is used to instantiate this class from a {@link Parcel}.
+     */
+    public static final Creator<GenresGroup> CREATOR = new GenresGroupParcelCreator();
+
+    /**
+     * This is a convenience string to use as a Intent extra tag.
+     */
+    public static final String EXTRA = "Genres";
+
+    private final String name;
+
+    private Set<Genre> genres = new HashSet<>();
+
+    public GenresGroup(final String name) {
+        assert name != null;
+        this.name = name;
+    }
+
+    public void addGenre(final Genre genre) {
+        genres.add(genre);
+    }
+
+    public Set<Genre> getGenres() {
+        return Collections.unmodifiableSet(genres);
+    }
+
+    @Override
+    public void writeToParcel(final Parcel dest, final int flags) {
+        dest.writeString(name);
+        dest.writeTypedList(new ArrayList<>(genres));
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        return o != null && (o == this || o.getClass() == this.getClass() && name.equals(((GenresGroup) o).name));
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    /**
+     * This class is used to instantiate a Genre Object from a {@code Parcel}.
+     */
+    private static final class GenresGroupParcelCreator implements Parcelable.Creator<GenresGroup> {
+
+        @Override
+        public GenresGroup createFromParcel(final Parcel source) {
+            final GenresGroup genresGroup = new GenresGroup(source.readString());
+            source.readParcelable(ResponseObject.LOADER);
+            final List<Genre> genres = new ArrayList<>();
+            source.readTypedList(genres, Genre.CREATOR);
+            genresGroup.genres = new HashSet<>(genres);
+            return genresGroup;
+        }
+
+        @Override
+        public GenresGroup[] newArray(final int size) {
+            return new GenresGroup[size];
+        }
+    }
+
+}

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/models/GenresGroup.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/models/GenresGroup.java
@@ -79,6 +79,11 @@ public class GenresGroup extends Item<GenresGroup> {
         return name.hashCode();
     }
 
+    @Override
+    public String toString() {
+        return !name.isEmpty() ? name : getGenres().iterator().next().toString();
+    }
+
     /**
      * This class is used to instantiate a Genre Object from a {@code Parcel}.
      */

--- a/MPDroid/src/main/res/values-de/strings.xml
+++ b/MPDroid/src/main/res/values-de/strings.xml
@@ -318,5 +318,8 @@
     <string name="mediaPlayerErrorUnsupported">Der Stream-Codec wird nicht unterstützt.</string>
     <string name="shufflePlaylist">Wiedergabeliste mischen</string>
     <string name="playlistShuffled">Wiedergabeliste wurde zufällig gemischt</string>
+    <string name="genreSeparators">Genre Trennzeichen</string>
+    <string name="optimizeGenres">Genre optimieren</string>
+    <string name="optimizeGenresDescription">Trenne und formatiere Genre</string>
     <!-- End MediaPlayer Error Strings -->
 </resources>

--- a/MPDroid/src/main/res/values/strings.xml
+++ b/MPDroid/src/main/res/values/strings.xml
@@ -182,6 +182,9 @@
     <string name="sortAlbumsByYearDescription">Sort albums by year</string>
     <string name="showAlbumTrackCount">Album track count</string>
     <string name="showAlbumTrackCountDescription">Show number of tracks on album</string>
+    <string name="optimizeGenres">Optimize genres</string>
+    <string name="optimizeGenresDescription">Split &amp; trim  genre values and adjust case</string>
+    <string name="genreSeparators">Genre separators</string>
     <string name="enableLocalCover">Download local cover art</string>
     <string name="enableLocalCoverDescription">Get cover art from the server running MPD (requires a web server, read the wiki!)</string>
     <string name="musicPath">Path to music</string>

--- a/MPDroid/src/main/res/values/strings.xml
+++ b/MPDroid/src/main/res/values/strings.xml
@@ -183,7 +183,7 @@
     <string name="showAlbumTrackCount">Album track count</string>
     <string name="showAlbumTrackCountDescription">Show number of tracks on album</string>
     <string name="optimizeGenres">Optimize genres</string>
-    <string name="optimizeGenresDescription">Split &amp; trim  genre values and adjust case</string>
+    <string name="optimizeGenresDescription">Split &amp; trim genre values and adjust case</string>
     <string name="genreSeparators">Genre separators</string>
     <string name="enableLocalCover">Download local cover art</string>
     <string name="enableLocalCoverDescription">Get cover art from the server running MPD (requires a web server, read the wiki!)</string>

--- a/MPDroid/src/main/res/xml/settings.xml
+++ b/MPDroid/src/main/res/xml/settings.xml
@@ -180,6 +180,24 @@
             android:persistent="true"
             android:summary="@string/showAlbumTrackCountDescription"
             android:title="@string/showAlbumTrackCount" />
+
+        <PreferenceCategory android:title="@string/genres" >
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="optimizeGenres"
+                android:persistent="true"
+                android:summary="@string/optimizeGenresDescription"
+                android:title="@string/optimizeGenres" />
+
+            <EditTextPreference
+                android:defaultValue="/,;|+"
+                android:key="genreSeparators"
+                android:dependency="optimizeGenres"
+                android:persistent="true"
+                android:title="@string/genreSeparators" />
+
+        </PreferenceCategory>
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
ID3 tagging does not support multiple genre values. To tag anyway multiple genres you have to separate them by some delimiter. Thus browsing by genre becomes difficult:
- Pop
- pop / rock
- Indie, Alternative, Pop
- Metal ; Thrash Metal

I have added a feature to optimize the genre browsing. It can be enabled/disabled via Preferences (also the delimiter characters). Each genre value will split and shown as a single genre:
- Pop
- Rock
- Indie
- Alternative
- Metal
- Thrash Metal

Browsing the genre 'Pop' shows all artists that match one of the three complex genres that contains 'Pop': 'Pop', 'pop / rock' & 'Indie, Alternative, Pop'.
In the implementation `GenreGroup` is used instead of `Genre` by the browsing fragments.
