### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Also, MPDroid's speed isn't that great, but considering that MPD's API was never
 
 So, the current roadmap is:
 
-####1.1  
+#### 1.1  
 
  - [ ] Make MPDroid configurable for multiple servers (Better implementation than the hackish WLAN based one)
  - [ ] Add Bonjour support


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
