### PR TITLE
Android 9 WiFi fixes

### DIFF
--- a/MPDroid/src/main/AndroidManifest.xml
+++ b/MPDroid/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <!-- Wake Lock for Streaming -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Required to get current WiFi network SSID -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name="com.namelessdev.mpdroid.MPDApplication"

--- a/MPDroid/src/main/java/com/namelessdev/mpdroid/WifiConnectionSettings.java
+++ b/MPDroid/src/main/java/com/namelessdev/mpdroid/WifiConnectionSettings.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.wifi.WifiConfiguration;
+import android.net.wifi.WifiInfo;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.preference.Preference;
@@ -89,6 +90,7 @@ public class WifiConnectionSettings extends PreferenceActivity {
         final PreferenceCategory preferenceCategory =
                 (PreferenceCategory) preferenceScreen.findPreference(KEY_WIFI_BASED_CATEGORY);
         List<WifiConfiguration> wifiList = null;
+        WifiInfo currentWifi = null;
 
         if (preference.getKey().equals(KEY_WIFI_BASED_SCREEN)) {
             /** Clear the wifi list. */
@@ -96,6 +98,7 @@ public class WifiConnectionSettings extends PreferenceActivity {
 
             final WifiManager wifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
             wifiList = wifiManager.getConfiguredNetworks();
+            currentWifi = wifiManager.getConnectionInfo();
         }
 
         if (wifiList == null) {
@@ -120,7 +123,7 @@ public class WifiConnectionSettings extends PreferenceActivity {
                 ssidItem.setTitle(ssid);
                 ssidItem.setIntent(intent);
 
-                if (WifiConfiguration.Status.CURRENT == wifi.status) {
+                if (currentWifi != null && currentWifi.getSSID().equals(wifi.SSID)) {
                     ssidItem.setSummary(R.string.connected);
                 } else {
                     ssidItem.setSummary(R.string.notInRange);


### PR DESCRIPTION
Request ACCESS_COARSE_LOCATION so that the SSID is visible
Use WifiManager.getConnectionInfo() to get the SSID

Fixes #856. Tested on a OnePlus 5.
